### PR TITLE
Fix: Login Button Route to Previous Page Instead of Homepage

### DIFF
--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -99,6 +99,10 @@ export default function ButtonAppBar (props) {
     window.location.reload()
   }
 
+  const login = () => {
+    localStorage.setItem('nextPage', window.location.pathname);
+  }
+
   const showUsername = () => (
     <ListItem button component = {Link} to = {"/profile/" + localStorage.getItem('netid')}  className={classes.usernameContainer}>
       <Avatar className = {classes.avatarIcon}/>
@@ -108,7 +112,7 @@ export default function ButtonAppBar (props) {
 
   const showLogin = () => (
       <ListItem className={classes.logInOutContainer} divider = "true" disableGutters = "true">
-        <LogInOutButton component = {Link} to = "/login">Login</LogInOutButton>
+        <LogInOutButton onClick = {() => {login()}} component = {Link} to = "/login">Login</LogInOutButton>
       </ListItem>
   )
 


### PR DESCRIPTION


# Description

The login button now routes back to the page it was previously on instead of defaulting to the new page. Essentially, on click of the login button in `navbar`, I implemented a function to set `nextPage` to the path of the current page in the localStorage. This allows the login & userAuth pages to redirect properly after logging in / onboarding flow. 

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested via repeated login and logout in the search page and a few of the ride summary pages. It functions for both users that exist (with completed first name) in our database as well as those who do not. 