### PR TITLE
CreateRide now redirects to the ride that was just created

### DIFF
--- a/client/src/Pages/CreateRide/CreateRide.js
+++ b/client/src/Pages/CreateRide/CreateRide.js
@@ -37,9 +37,11 @@ const CreateRide = () => {
         createRide({
             variables: ride
         })
-        .then(() => {
+        .then((obj) => {
             addToast("Congratulations! Your ride has been successfully created.", { appearance: 'success'});
+            const rideID = obj.data.rideCreateOne.record._id;
             console.log("success!");
+            window.open('/ridesummary/' + rideID, '_self');
         })
         .catch((error) => {
             console.log("error", error);


### PR DESCRIPTION
# Description

Originally, createRide page does not redirect the user to the ride summary page of the ride that was just created. Now, it does!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a couple of rides and they redirect to the correct ride summary page ( same time, start location, departure location, etc.). 
