### PR TITLE
Ride summary back button fix

### DIFF
--- a/client/src/Pages/CreateRide/CreateRide.js
+++ b/client/src/Pages/CreateRide/CreateRide.js
@@ -4,9 +4,9 @@ import { gql, useMutation } from "@apollo/client";
 import { useToasts } from "react-toast-notifications";
 
 const CreateRide = () => {
-
+    
     const { addToast } = useToasts();
-
+    localStorage.setItem('lastPage', 'create-ride');
     const CREATE_RIDE = gql`
         mutation CreateRide (
             $startLoc: MongoID!, $endLoc: MongoID!, $date: Date, $passengers: Float, $users: [MongoID!], $owner: MongoID!) 

--- a/client/src/Pages/CreateRide/CreateRide.js
+++ b/client/src/Pages/CreateRide/CreateRide.js
@@ -6,6 +6,7 @@ import { useToasts } from "react-toast-notifications";
 const CreateRide = () => {
     
     const { addToast } = useToasts();
+    // Set the last page visited
     localStorage.setItem('lastPage', 'create-ride');
     const CREATE_RIDE = gql`
         mutation CreateRide (

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -82,7 +82,8 @@ const RideSummary = () => {
   const { data, loading, error } = useQuery(GET_RIDE, {
     variables: {id: id},
   })
- 
+ // Search or rideCreation pages
+ // Use local storage: set variable and go back to that
 
   const JOIN_RIDE = gql`
     mutation JoinRide($rideID: ID!) {
@@ -124,6 +125,12 @@ const RideSummary = () => {
     joinRide()
   }
 
+  const goBack = () => {
+    let lastPage = '/' + localStorage.getItem('lastPage');
+    console.log(lastPage);
+    history.push(lastPage);
+  }
+
   const time = moment(ride.departureDate)
   const mon = time.format('MMM').toString()
   const day = time.format('DD').toString()
@@ -131,7 +138,7 @@ const RideSummary = () => {
 
   return (
     <AllDiv>
-      <BackArrowDiv>
+      <BackArrowDiv onClick={() => goBack()}>
         <IoIosArrowBack></IoIosArrowBack>
       </BackArrowDiv>
       <RideSummaryDiv>

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -82,9 +82,8 @@ const RideSummary = () => {
   const { data, loading, error } = useQuery(GET_RIDE, {
     variables: {id: id},
   })
- // Search or rideCreation pages
- // Use local storage: set variable and go back to that
 
+  
   const JOIN_RIDE = gql`
     mutation JoinRide($rideID: ID!) {
       addRider(rideID: $rideID) {
@@ -127,7 +126,6 @@ const RideSummary = () => {
 
   const goBack = () => {
     let lastPage = '/' + localStorage.getItem('lastPage');
-    console.log(lastPage);
     history.push(lastPage);
   }
 

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -71,7 +71,6 @@ const GET_RIDE = gql`
 `
 const RideSummary = () => {
   let { id } = useParams()
-  // const [getVariables, setVariables] = useState({})
   const [ride, setRide] = useState({
     departureLocation: {title: "Loading"},
     arrivalLocation: {title: "Loading"},
@@ -99,7 +98,13 @@ const RideSummary = () => {
 
   useEffect(() => {
     if (data) {
-      let ride = {...data.rideOne,owner:{netid:"mbo",lastName:"Temp",firstName:"Temp"}}
+      let ride;
+      if(!data.rideOne.owner){
+        ride = {...data.rideOne,owner:{netid:"err",lastName:"owner",firstName:"No"}}
+      }
+      else {
+        ride = {...data.rideOne}
+      }
       setRide(ride)
       console.log(ride)
     }
@@ -108,7 +113,6 @@ const RideSummary = () => {
   if (error) return <p>Error.</p>
   if (loading) return <p>Loading...</p>
   if (!data) return <p>No data...</p>
-  // const { rideOne: ride } = data
 
   const join = () => {
     if (localStorage.getItem('token') == null) {
@@ -145,7 +149,6 @@ const RideSummary = () => {
             <LocationText>
               <DepartureIconDiv style={{ fontSize: '7vw' }}></DepartureIconDiv>
               <DepartureDiv>
-                {/* Rice Univ */}
                 {ride.departureLocation.title}
               </DepartureDiv>
               <LocationArrowDiv>

--- a/client/src/Pages/Search/Search.js
+++ b/client/src/Pages/Search/Search.js
@@ -17,9 +17,9 @@ const LoadingDiv = styled.div`
   justify-content: center;
   align-items: center;
 `
-
 const Search = () => {
-
+  // Set last page visited
+  localStorage.setItem('lastPage', 'search');
   let resultDestArr = [];
     
   const displayRef = React.useRef();


### PR DESCRIPTION
# Description
Implemented functionality of back button for RideSummary page. Back button redirects user to either search or ride creation pages. Implemented using localstorage to avoid issues of going back to /login with useHistory().

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested by selecting a ride from /search (navigates to /ridesummary) and selected back button to get back to /search. Unable to test functionality from the ride creation side because /create-ride doesn't redirect upon creation yet (fix for this is in another PR). 
