### PR TITLE
fixed toasts!

### DIFF
--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -10,6 +10,9 @@ import { gql, useQuery} from "@apollo/client";
 import { useEffect } from 'react';
 
 const useStyles = makeStyles((theme) => ({
+  appbarRoot: {
+    zIndex:"999"
+  },
   icon: {
     color:"#002140",
   },
@@ -143,7 +146,7 @@ export default function ButtonAppBar (props) {
     <div>
     {showBar ?
     <div>
-        <AppBar position="fixed" color="white" elevation="0"> 
+        <AppBar position="fixed" color="white" elevation="0" className={classes.appbarRoot}> 
           <Toolbar>
             <IconButton edge="start" className={classes.icon} onClick = {toggleDrawer} aria-label="menu">
               <MenuIcon fontSize="large"/>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -32,7 +32,7 @@ render(
     <ThemeProvider theme = {theme}>
         <ApolloProvider client={client}>
         <Router history={history}>
-            <ToastProvider>
+            <ToastProvider autoDismiss>
                 <Routes />
             </ToastProvider>
         </Router>


### PR DESCRIPTION
added auto dismiss and changed the z-index of the nav bar

# Description

Added auto dismiss to the ToastProvider, which applies it to all toasts.
Also changed the zindex of the nav bar to make it smaller than the toast's zindex.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Nav Bar still works as usual; toasts now disappear after 5 seconds.