### PR TITLE
Fix: CreateRide Page Error "Cannot destructure property 'locationMany'"

### DIFF
--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -53,6 +53,7 @@ const Create = ({onCreate}) => {
     const [date, setDate] = useState(new Date())
     const [passengers, setPassengers] = useState(4)
     const [confirmation, setConfirmation] = useState(false)
+    const [queryCompletes, setQueryCompletes] = useState(false)
 
     const onSubmit = (e) => {
         e.preventDefault()
@@ -134,9 +135,9 @@ const Create = ({onCreate}) => {
         }
     }`
 
-    const { data: locationData } = useQuery(GET_LOCATIONS);
+    const { data: locationData, loading: locationLoading} = useQuery(GET_LOCATIONS);
 
-    const { data: userData, loading, error } = useQuery(GET_USER, 
+    const { data: userData, loading: userLoading, error } = useQuery(GET_USER, 
         {
             variables: 
             {
@@ -145,7 +146,7 @@ const Create = ({onCreate}) => {
         }
     );
 
-    if (loading) return 'Loading...';
+    if (locationLoading || userLoading) return 'Loading...';
     if (error) return `Error! ${error.message}`;
 
     const {locationMany: locations} = locationData


### PR DESCRIPTION
# Description

Hypothesis for the page breaking error "TypeError: Cannot destructure property 'locationMany' of 'locationData' as it is undefined": the Query for locations is incomplete, but a variable attempts to accessed the returned data before the completion. The fix I have implemented is to track for the loading state and return a loading div. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

An attempt to recreate the issue with useHistory(nextPage) instead of window.open in the Auth and UserAuth pages were unable to break the page. Previously, during my development of onboarding prompt, these two code chunks would always lead to the error. Also, was unable to recreate the issue via other actions (including how Shreyas arrive at the error: login at search page -> click on create ride button on search page-> error should occur but it doesn't. 
