### PR TITLE
YourRides page horizontal scrollbar fix

### DIFF
--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -82,7 +82,7 @@ const YourRides = (paid) => {
     if (loading) return <p>loading...</p>;
 
     return (
-        <div> 
+        // <div> 
             <OverallPage>
                 <OverallPageTitle>Your Rides</OverallPageTitle>
                 <UpcomingRidesSection>
@@ -114,7 +114,7 @@ const YourRides = (paid) => {
                     })}
                 </PastRidesSection>
             </OverallPage>
-        </div>
+        // </div>
     )
 }
 

--- a/client/src/Pages/YourRides/YourRidesStyles.js
+++ b/client/src/Pages/YourRides/YourRidesStyles.js
@@ -5,6 +5,7 @@ display: flex;
 align-items: center;
 flex-direction: column;
 font-family: Josefin Sans;
+overflow-x: hidden;
 `;
 
 const OverallPageTitle = styled.div`

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -106,42 +106,42 @@ export default function ButtonAppBar (props) {
     localStorage.setItem('nextPage', window.location.pathname);
   }
 
-  const showUsername = () => (
-    <ListItem button component = {Link} to = {"/profile/" + localStorage.getItem('netid')}  className={classes.usernameContainer}>
+  const showUsername = (toggleDrawer) => (
+    <ListItem button component = {Link} to = {"/profile/" + localStorage.getItem('netid')}  className={classes.usernameContainer} onClick = {toggleDrawer}>
       <Avatar className = {classes.avatarIcon}/>
       <ListItemText className = {classes.text} primary = {user.firstName + " " + user.lastName}/>
     </ListItem>
   )
 
-  const showLogin = () => (
-      <ListItem className={classes.logInOutContainer} divider = "true" disableGutters = "true">
+  const showLogin = (toggleDrawer) => (
+      <ListItem className={classes.logInOutContainer} divider = "true" disableGutters = "true" onClick = {toggleDrawer}>
         <LogInOutButton onClick = {() => {login()}} component = {Link} to = "/login">Login</LogInOutButton>
       </ListItem>
   )
 
-  const showLogout = () => (
-    <ListItem className={classes.logInOutContainer}>
+  const showLogout = (toggleDrawer) => (
+    <ListItem className={classes.logInOutContainer} onClick = {toggleDrawer}>
       <LogInOutButton onClick = {() => {logout()}}>Logout</LogInOutButton>
     </ListItem>
   )
 
   // Eventually should make this extensible
-  const drawerItems = () => (
+  const drawerItems = (toggleDrawer) => (
     <div>
       <List className = {classes.list}>
-        {loggedIn ? showUsername() : showLogin()}
-        <ListItem button component = {Link} to = "/home">
+        {loggedIn ? showUsername(toggleDrawer) : showLogin(toggleDrawer)}
+        <ListItem button component = {Link} to = "/home" onClick = {toggleDrawer}>
           <ListItemIcon className= {classes.icon}> <HomeIcon/> </ListItemIcon>
           <ListItemText className = {classes.text} primary = "Home"/>
         </ListItem>
-        <ListItem button disabled = {!loggedIn} component = {Link} to = "/your-rides">
+        <ListItem button disabled = {!loggedIn} component = {Link} to = "/your-rides" onClick = {toggleDrawer}>
           <ListItemIcon className = {classes.icon}> <CarIcon/> </ListItemIcon>
           <ListItemText className = {classes.text} primary = "Your Rides"/>
         </ListItem>
-        <ListItem button className = {classes.bottomItem} component = {Link} to = "/about">
+        <ListItem button className = {classes.bottomItem} component = {Link} to = "/about" onClick = {toggleDrawer}>
           <ListItemText className = {classes.text} primary = "About"/>
         </ListItem>
-        {loggedIn ? showLogout() : null}
+        {loggedIn ? showLogout(toggleDrawer) : null}
       </List>
     </div>
   );
@@ -154,10 +154,10 @@ export default function ButtonAppBar (props) {
           <Toolbar>
             <IconButton edge="start" className={classes.icon} onClick = {toggleDrawer} aria-label="menu">
               <MenuIcon fontSize="large"/>
-                <Drawer anchor = "left" open = {drawer} onClose = {toggleDrawer}>
-                  {drawerItems()}
-                </Drawer>
             </IconButton>
+            <Drawer anchor = "left" open = {drawer} onClose = {toggleDrawer}>
+                  {drawerItems(toggleDrawer)}
+            </Drawer>
           </Toolbar>
         </AppBar>
         <Toolbar/>

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -99,7 +99,10 @@ export default function ButtonAppBar (props) {
 
   const logout = () => {
     localStorage.clear();
-    window.location.reload()
+    //window.location.reload()
+    window.location.replace("/home")
+    
+
   }
 
   const login = () => {
@@ -114,14 +117,14 @@ export default function ButtonAppBar (props) {
   )
 
   const showLogin = (toggleDrawer) => (
-      <ListItem className={classes.logInOutContainer} divider = "true" disableGutters = "true" onClick = {toggleDrawer}>
-        <LogInOutButton onClick = {() => {login()}} component = {Link} to = "/login">Login</LogInOutButton>
+      <ListItem className={classes.logInOutContainer} divider = "true" disableGutters = "true">
+        <LogInOutButton onClick = {() => {toggleDrawer(); login();}} component = {Link} to = "/login">Login</LogInOutButton>
       </ListItem>
   )
 
   const showLogout = (toggleDrawer) => (
-    <ListItem className={classes.logInOutContainer} onClick = {toggleDrawer}>
-      <LogInOutButton onClick = {() => {logout()}}>Logout</LogInOutButton>
+    <ListItem className={classes.logInOutContainer}>
+      <LogInOutButton onClick = {() => {toggleDrawer(); logout();}}>Logout</LogInOutButton>
     </ListItem>
   )
 
@@ -130,7 +133,7 @@ export default function ButtonAppBar (props) {
     <div>
       <List className = {classes.list}>
         {loggedIn ? showUsername(toggleDrawer) : showLogin(toggleDrawer)}
-        <ListItem button component = {Link} to = "/home" onClick = {toggleDrawer}>
+        <ListItem button component = {Link} to = "/search" onClick = {toggleDrawer}>
           <ListItemIcon className= {classes.icon}> <HomeIcon/> </ListItemIcon>
           <ListItemText className = {classes.text} primary = "Home"/>
         </ListItem>


### PR DESCRIPTION
# Description
Horizontal scroll bar appeared on YourRides page at the bottom. Removed bar, yet issue with the text on the ride card not scaling for smaller screen sizes (Ex: IPhone SE) remains.
This issue might be resolved once locations are abbreviated (another to-do issue on task board).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Loaded page on multiple screen sizes and was unable to access horizontal scroll bar.