### PR TITLE
Created clearable fields

### DIFF
--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -146,7 +146,10 @@ const FormOnly = (props) => {
               variant='outlined'
               size='small'
           >
-              {
+              <MenuBox value="">
+                None
+              </MenuBox>
+              { 
                   PossibleLocations.map((option, locInd) => (
                       <MenuBox key = {option._id} value = {locInd}>
                           {option.title}
@@ -167,6 +170,9 @@ const FormOnly = (props) => {
                 variant='outlined'
                 size='small'
             >
+              <MenuBox value="">
+                None
+              </MenuBox>
               {
                   PossibleLocations.map((option, locInd) => (
                       <MenuBox key = {option._id} value = {locInd}>


### PR DESCRIPTION
# Description

A new option appears in the "Departure Location" and "Destination" Select boxes named _None_ that clears the field, essentially setting the value to be "".

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)\

# How Has This Been Tested?
 Clearing the field removes/adds to the list of matching rides as expected.