### PR TITLE
Changed the link to be the entire ride component

### DIFF
--- a/client/src/Pages/Search/Ride.js
+++ b/client/src/Pages/Search/Ride.js
@@ -4,6 +4,7 @@ import Box from '@material-ui/core/Box';
 import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import { BoxRide } from './DisplayRides.styles';
+import { Link } from '@material-ui/core';
 
 function renderDate(date) {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -17,15 +18,15 @@ const Ride = ({ride}) => {
     const date = new Date(ride.departureDate);
 
     return (
-        <Grid container key={ride._id} xs={11} alignItems='stretch' style={{height: '100%', display: 'flex', borderRadius: '10px'}}>
+        <Link href={`/ridesummary/${ride._id}`} style={{textDecoration: 'none'}}>
+        <Grid container key={ride._id} xs={12} alignItems='stretch' style={{height: '100%', width: "90vw", display: 'flex', borderRadius: '10px'}}>
             <Grid item container  style={{height:"16vh", backgroundColor: "white", borderRadius: '10px', borderColor:'', boxShadow: '0px 3px 10px #bbdaff'}}>
                 <Grid item xs={3} justify="center" align='center' style={{display: 'flex', placeItems: 'center'}}>
-                    <a href={`/ridesummary/${ride._id}`} style={{textDecoration: 'none'}}>
+                    
                         <Box width={"60%"} height={"75%"} style={{display: 'flex', flexDirection: 'column', backgroundColor: 'rgba(187, 218, 255, 0.22)', borderRadius: '5px', justifyContent: 'center'}}>
                             <span style={{fontSize: '4vw', fontFamily: 'Josefin Sans'}}>{ride.spots}</span>
                             <span style={{fontSize: '2.5vw', fontFamily: 'Josefin Sans'}}>seats left</span>  
                         </Box>
-                    </a>
                 </Grid>
 
                 <Grid item xs={2} justify="center" align='center'>
@@ -55,6 +56,7 @@ const Ride = ({ride}) => {
                 </Grid>
             </Grid>
         </Grid>
+        </Link>
     );
 }
 


### PR DESCRIPTION
# Description
In the search rides page, now the entire ride component is a link to the its corresponding summary page.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Clicking on a ride in search page does redirect the user to the corresponding ride summary page.