### PR TITLE
Fixed Dropdown item positioning for all select boxes (both search and create rides pages)

### DIFF
--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -161,6 +161,17 @@ const Create = ({onCreate}) => {
                 >   
                     <InputBox id = 'StartLoc'>Departure Location</InputBox>
                     <SelectBox
+                        MenuProps={{
+                            anchorOrigin: {
+                                vertical: "bottom",
+                                horizontal: "left"
+                            },
+                            transformOrigin: {
+                                vertical: "top",
+                                horizontal: "left"
+                            },
+                            getContentAnchorEl: null
+                        }}
                         id="Start Location Search Bar"
                         labelId='StartLoc'
                         value={startLoc}
@@ -185,6 +196,17 @@ const Create = ({onCreate}) => {
                 >
                     <InputBox id = 'EndLoc'>Destination</InputBox>
                     <SelectBox
+                        MenuProps={{
+                            anchorOrigin: {
+                                vertical: "bottom",
+                                horizontal: "left"
+                            },
+                            transformOrigin: {
+                                vertical: "top",
+                                horizontal: "left"
+                            },
+                            getContentAnchorEl: null
+                        }}
                         id="End Location Search Bar"
                         labelId='Endloc'
                         value={endLoc}

--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -203,6 +203,7 @@ const FormOnly = (props) => {
             direction='row'
             justifyContent='center'
             alignItems='center'
+            spacing = "1"
           >
             <Grid item>
               <Select 

--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -139,6 +139,17 @@ const FormOnly = (props) => {
 
           <InputBox id = 'StartLoc'>Departure Location</InputBox>
           <SelectBox
+              MenuProps={{
+                anchorOrigin: {
+                  vertical: "bottom",
+                  horizontal: "left"
+                },
+                transformOrigin: {
+                  vertical: "top",
+                  horizontal: "left"
+                },
+                getContentAnchorEl: null
+              }}
               id="Start Location Search Bar"
               labelId='StartLoc'
               value={startLoc}
@@ -160,6 +171,17 @@ const FormOnly = (props) => {
         <Grid  item xs = {12}>
           <InputBox id = 'EndLoc'>Destination</InputBox>
             <SelectBox
+                MenuProps={{
+                  anchorOrigin: {
+                    vertical: "bottom",
+                    horizontal: "left"
+                  },
+                  transformOrigin: {
+                    vertical: "top",
+                    horizontal: "left"
+                  },
+                  getContentAnchorEl: null
+                }}
                 id="End Location Search Bar"
                 labelId='EndLoc'
                 value={endLoc}

--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -5,11 +5,11 @@ import DateFnsUtils from '@date-io/date-fns';
 
 import {
     MenuItem,
+    Select,
     Grid, 
 } from '@material-ui/core';
 
-import "@fontsource/source-sans-pro";
-import TextField from '@material-ui/core/TextField';
+import "@fontsource/source-sans-pro"; 
 import {
   Form,
   SelectBox,
@@ -198,23 +198,36 @@ const FormOnly = (props) => {
           </Grid>
         </Grid>
         <Grid  item xs = {12}>
-          <Grid
+          <Grid 
             container
             direction='row'
             justifyContent='center'
             alignItems='center'
-            spacing = '1'
           >
-            <Grid item>   
-            <TextField id="number-people" select value={numberPeople} onChange={e => {setNumberPeople(e.target.value);}}>
-              { [1,2,3,4,5,6,7,8,9,10,11,12,13].map((ele) => (
-                <MenuItem key={ele} value={ele}>{ele}</MenuItem>
-              ))}
-            </TextField>
-          </Grid>
-          <Grid item>
+            <Grid item>
+              <Select 
+                MenuProps={{
+                  anchorOrigin: {
+                    vertical: "bottom",
+                    horizontal: "left"
+                  },
+                  transformOrigin: {
+                    vertical: "top",
+                    horizontal: "left"
+                  },
+                  getContentAnchorEl: null
+                }} 
+                id="number-people" 
+                value={numberPeople} 
+                onChange={e => {setNumberPeople(e.target.value);}}>
+                  { [1,2,3,4,5].map((ele) => (
+                  <MenuItem value={ele}>{ele}</MenuItem>
+                  ))}
+              </Select>
+            </Grid>
+            <Grid item>
               <BodyText>{"Number of People"}</BodyText> 
-          </Grid>
+            </Grid>        
         </Grid>
       </Grid>
     </Grid>

--- a/client/src/Pages/Search/FormOnly.styles.js
+++ b/client/src/Pages/Search/FormOnly.styles.js
@@ -60,7 +60,7 @@ export const MenuBox = withStyles({
         justifyContent: 'center',
         alignItems: 'center',
         background: 'white',
-        width: '65vw',
+        width: '100%',
         border: 0,
         color: '#0B3669',
         height: 36,


### PR DESCRIPTION
# Description
Fixed the positioning of the dropdown items to where it is located beneath the select box. This applies to the "Number of People", "Departure Location", and "Destination" boxes in the search rides page. And similar boxes in the create rides page.
Also, changed the maximum number of the people in the search ride from 13 to 5.
## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Dropdown items look fine on web as mobile. !! However, on wider screens, the dropdown item extend past the box itself. !! 