### PR TITLE
Prevent creating rides from a place to itself

### DIFF
--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -65,6 +65,11 @@ const Create = ({onCreate}) => {
             return
         }   
 
+        if (startLoc === endLoc) {
+            addToast("Ride departure and destination locations must be different.", { appearance: 'error' });
+            return;
+        }
+
         if (!confirmation) {
             addToast("You must agree to lead the ride to create this ride.", { appearance: 'error' });
             return


### PR DESCRIPTION
# Description

The Create Ride form no longer lets you submit if the start and end locations are identical. It shows an error toast instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to the Create Ride page
- Select the same location under the "Departure Location" and "Destination" dropdowns
- Enter a valid value for the date/time and check the "I will be responsible …" checkbox
- Press "Create New Ride"
- The ride shouldn't be created, you shouldn't be redirected to a ride summary page, and a toast indicating the error should show up