### PR TITLE
Fix issues with the onboarding form's handling of payment info

### DIFF
--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -11,9 +11,15 @@ const Onboarding = () => {
       $firstName: String!
       $lastName: String!
       $phone: String!
+      $payment: JSON!
     ) {
       userUpdateOne(
-        record: { firstName: $firstName, lastName: $lastName, phone: $phone }
+        record: {
+          firstName: $firstName,
+          lastName: $lastName,
+          phone: $phone,
+          payment: $payment,
+        }
       ) {
         record {
           _id
@@ -28,6 +34,8 @@ const Onboarding = () => {
   const [updateUser] = useMutation(UPDATE_USER);
 
   const updateUserInfo = (formData) => {
+    console.log(formData);
+    
     updateUser({ variables: formData });
 
     const nextPage = localStorage.getItem("nextPage");

--- a/client/src/Pages/Profile/ProfileForm.js
+++ b/client/src/Pages/Profile/ProfileForm.js
@@ -73,9 +73,9 @@ const ProfileForm = ({ onSubmit }) => {
               label="Options"
               onChange={(e) => setPaymentOption(e.target.value)}
             >
-              <MenuItem value={10}>Venmo</MenuItem>
-              <MenuItem value={20}>Zelle</MenuItem>
-              <MenuItem value={30}>Other</MenuItem>
+              <MenuItem value="Venmo">Venmo</MenuItem>
+              <MenuItem value="Zelle">Zelle</MenuItem>
+              <MenuItem value="Other">Other</MenuItem>
             </Select>
           </FormControl>
         </Box>
@@ -92,7 +92,12 @@ const ProfileForm = ({ onSubmit }) => {
         <Button
           variant="contained"
           onClick={() => {
-            onSubmit({ firstName, lastName, phone });
+            onSubmit({
+              firstName,
+              lastName,
+              phone,
+              payment: { [paymentOption]: paymentAccount }
+            });
           }}
         >
           Submit


### PR DESCRIPTION
# Description

Makes the onboarding form appropriately handle payment info which was previously being ignored.

I noticed that there's a lot of duplication between `client/src/Pages/Profile/ProfileForm.js` and `client/src/Pages/Profile/ProfileDialog.js`. They do almost the exact same thing. The only difference is that `ProfileDialog.js` also has a dialog box around its implementation of the form. The onboarding page uses `ProfileForm.js` while the edit button on the profile page uses `ProfileDialog.js`. While `ProfileDialog.js` was updated to implement payment info, `ProfileForm.js` wasn't. This patch fixes that. We might want to combine the two at some point.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please include:
- Delete the user with your netid from the DB
- Login
- Fill the onboarding form (take note of the payment info you enter)
- Navigate to the profile page and confirm that the payment info matches your submission