### PR TITLE
Routes user to user profiles on click (within ride summary page)

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -183,7 +183,8 @@ const RideSummary = () => {
       <RidersDiv>
         <HostDiv>Host</HostDiv>
         <RidersComponents>
-        <OneRiderContainer>
+          <div onClick={e => history.push("/profile/" + ride.owner.netid)}>
+            <OneRiderContainer>
                 <div key={ride.owner.netid}>
                   <IoPersonCircleSharpDiv>
                     <IoPersonCircleSharp></IoPersonCircleSharp>
@@ -192,12 +193,13 @@ const RideSummary = () => {
                 <RiderText>
                 {ride.owner.firstName}&nbsp;{ride.owner.lastName}
                 </RiderText>
-          </OneRiderContainer>
+              </OneRiderContainer>
+            </div>
           <LineDiv>
             <hr></hr>
           </LineDiv>
           {ride.riders.slice(0, 3).map((person) => (
-            <div>
+            <div onClick={e => history.push("/profile/" + person.netid)}>
               <OneRiderContainer>
                 <div key={person.netid}>
                   <IoPersonCircleSharpDiv>


### PR DESCRIPTION
# Description

When a user clicks on another person added on a given ride from the Ride Summary page, the user will be routed to that person's profile.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested to ensure the profile information that shows up is the correct information!

