### PR TITLE
Remove Zelle and `Other` payment options

### DIFF
--- a/api/models/UserModel.js
+++ b/api/models/UserModel.js
@@ -10,7 +10,7 @@ var UserSchema = new Schema({
   firstName: String,
   lastName: String,
   phone: String,
-  payment: { type: {}, default: { Venmo: "", Zelle: "", Other: "" } },
+  venmo: String,
   token: { type: String, default: "" }, // We will use this to store the user's JWT token
   recentUpdate: { type: Boolean, default: false }, // this field used for displaying banners/modals on version updates of our app
 });

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -11,14 +11,14 @@ const Onboarding = () => {
       $firstName: String!
       $lastName: String!
       $phone: String!
-      $payment: JSON!
+      $venmo: String
     ) {
       userUpdateOne(
         record: {
           firstName: $firstName,
           lastName: $lastName,
           phone: $phone,
-          payment: $payment,
+          venmo: $venmo,
         }
       ) {
         record {
@@ -26,6 +26,7 @@ const Onboarding = () => {
           firstName
           lastName
           phone
+          venmo
         }
       }
     }

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -103,12 +103,18 @@ const Profile = () => {
           <StyledText>{user.netid}@rice.edu</StyledText>
         </TextBox>
         <TextBox
-          onClick={() => {
-            navigator.clipboard.writeText("@comp182Luay").then(
-              addToast("Venmo ID Copied to Clipboard!", {
-                appearance: "success",
+          onClick={async () => {
+            if (user.venmo) {
+              navigator.clipboard.writeText(user.venmo).then(
+                addToast("Venmo ID Copied to Clipboard!", {
+                  appearance: "success",
+                })
+              );
+            } else {
+              addToast("Venmo ID Not Specified", {
+                appearance: "error",
               })
-            );
+            }
           }}
         >
           <StyledText2>

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -115,7 +115,7 @@ const Profile = () => {
             Venmo
           </StyledText2>
           <StyledText>
-            {user.venmo || "Not Specified"}
+            {user.venmo ? `@${user.venmo}` : "Not Specified"}
           </StyledText>
         </TextBox>
       </ProfileCard>

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -35,7 +35,7 @@ const Profile = () => {
         lastName
         netid
         phone
-        payment
+        venmo
       }
     }
   `;
@@ -61,21 +61,6 @@ const Profile = () => {
   function goBack() {
     window.history.back();
   }
-
-  const paymentKeys = user.payment ? Object.keys(user.payment) : undefined; //["Venmo", "Zelle", "Other"]
-  let paymentType = "";
-
-  //set paymentType to Venmo or Zelle or Other, in that order of priority
-  if (paymentKeys) {
-    if (user.payment["Venmo"] && user.payment["Venmo"] !== "") {
-      paymentType = "Venmo";
-    } else if (user.payment["Zelle"] && user.payment["Zelle"] !== "") {
-      paymentType = "Zelle";
-    } else {
-      paymentType = "Other";
-    }
-  }
-  console.log("paymentType", paymentType);
 
   return (
     <div>
@@ -127,12 +112,10 @@ const Profile = () => {
           }}
         >
           <StyledText2>
-            {user.payment[paymentType] !== ""
-              ? paymentType
-              : "No Payment Specified"}
+            Venmo
           </StyledText2>
           <StyledText>
-            {user.payment[paymentType] !== "" ? user.payment[paymentType] : ""}
+            {user.venmo || "Not Specified"}
           </StyledText>
         </TextBox>
       </ProfileCard>

--- a/client/src/Pages/Profile/ProfileDialog.js
+++ b/client/src/Pages/Profile/ProfileDialog.js
@@ -1,4 +1,4 @@
-import { Dialog, MenuItem } from "@material-ui/core";
+import { Dialog } from "@material-ui/core";
 import React, { useState } from "react";
 import { useToasts } from "react-toast-notifications";
 import {
@@ -12,8 +12,6 @@ import {
   Label,
   InputTextField,
   InputBox,
-  PaymentSelect,
-  ProfileStyles,
   SaveButton,
 } from "./ProfileDialogStyles";
 import { gql, useMutation } from "@apollo/client";
@@ -24,14 +22,14 @@ export default function ProfileDialog(props) {
       $firstName: String!
       $lastName: String!
       $phone: String!
-      $payment: JSON!
+      $venmo: String
     ) {
       userUpdateOne(
         record: {
           firstName: $firstName
           lastName: $lastName
           phone: $phone
-          payment: $payment
+          venmo: $venmo
         }
       ) {
         record {
@@ -39,7 +37,7 @@ export default function ProfileDialog(props) {
           firstName
           lastName
           phone
-          payment
+          venmo
         }
       }
     }
@@ -60,50 +58,25 @@ export default function ProfileDialog(props) {
     payment: profileUser.payment ? profileUser.payment : {},
   });
 
-  const classes = ProfileStyles();
-
   const closeDialog = () => {
     setOpenDialog(false);
   };
-
-  function selectPayment(e) {
-    setUser((prestate) => {
-      const newPaymentMethod = e.target.value;
-      const newPayment = prestate.payment[newPaymentMethod]
-        ? prestate.payment[newPaymentMethod]
-        : "";
-      return {
-        ...prestate,
-        selectedPaymentMethod: newPaymentMethod,
-        selectedPayment: newPayment,
-      };
-    });
-  }
 
   function setUserPayment(e) {
     const newPayment = e.target.value;
     setUser((prestate) => {
       return {
         ...prestate,
-        payment: {
-          ...prestate.payment,
-          [prestate.selectedPaymentMethod]: newPayment,
-        },
-        selectedPayment: newPayment,
+        venmo: newPayment,
       };
     });
   }
 
-  function clearUserPayment(type) {
-    console.log("type", type);
+  function clearUserPayment() {
     setUser((prestate) => {
       return {
         ...prestate,
-        payment: {
-          ...prestate.payment,
-          [type]: "",
-        },
-        selectedPayment: "",
+        venmo: undefined,
       };
     });
   }
@@ -180,29 +153,18 @@ export default function ProfileDialog(props) {
           </InputBox>
 
           <InputBox>
-            <Label>Payments:</Label>
-            <PaymentSelect
-              variant="outlined"
-              margin="dense"
-              defaultValue={user.selectedPaymentMethod}
-              classes={{ root: classes.inputLabel }}
-              onChange={(e) => selectPayment(e)}
-            >
-              <MenuItem value="Venmo">Venmo</MenuItem>
-              <MenuItem value="Zelle">Zelle</MenuItem>
-              <MenuItem value="Other">Other</MenuItem>
-            </PaymentSelect>
+            <Label>Venmo:</Label>
             <InputTextField
               label="Account ID"
-              name="selectedPayment"
-              defaultValue={user.selectedPayment}
-              value={user.selectedPayment}
+              name="venmo"
+              defaultValue={user.venmo}
+              value={user.venmo}
               onChange={(e) => {
                 setUserPayment(e);
               }}
               clearTextField={() => {
-                clearUserPayment(user.selectedPaymentMethod);
-                console.log(user.payment);
+                clearUserPayment();
+                console.log(user.venmo);
               }}
             ></InputTextField>
           </InputBox>

--- a/client/src/Pages/Profile/ProfileForm.js
+++ b/client/src/Pages/Profile/ProfileForm.js
@@ -7,20 +7,14 @@ import {
 } from "./ProfileFormStyles";
 import React, { useState } from "react";
 import { TextField } from "@material-ui/core";
-import MenuItem from "@material-ui/core/MenuItem";
 import Button from "@material-ui/core/Button";
-import Box from "@material-ui/core/Box";
-import InputLabel from "@material-ui/core/InputLabel";
-import FormControl from "@material-ui/core/FormControl";
-import Select from "@material-ui/core/Select";
 
 const ProfileForm = ({ onSubmit }) => {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
-  const [paymentOption, setPaymentOption] = useState("");
-  const [paymentAccount, setPaymentAccount] = useState("");
+  const [venmo, setVenmo] = useState(undefined);
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -28,7 +22,7 @@ const ProfileForm = ({ onSubmit }) => {
         return onSubmit({
             firstName, lastName,
             email, phone,
-            paymentOption, paymentAccount
+            venmo
         });
     };
 
@@ -51,25 +45,8 @@ const ProfileForm = ({ onSubmit }) => {
             </EditContactInfo>    
             <EditPaymentOptions>
                 Payment
-                <Box sx = {{minWidth: 120}}>
-                    <FormControl fullWidth>
-                        <InputLabel id="demo-simple-select-label">Options</InputLabel>
-                        <Select
-                            labelId="demo-simple-select-label"
-                            id="demo-simple-select"
-                            value={paymentOption}
-                            label="Options"
-                            required
-                            onChange={(e) => setPaymentOption(e.target.value)}
-                        >
-                            <MenuItem value="Venmo">Venmo</MenuItem>
-                            <MenuItem value="Zelle">Zelle</MenuItem>
-                            <MenuItem value="Other">Other</MenuItem>
-                        </Select>
-                    </FormControl>
-                </Box>
                 <br></br>
-                <TextField id = "outlined-filled" label = "Pay to @" variant = "filled" value={paymentAccount} required onChange={(e) => setPaymentAccount(e.target.value)}/>
+                <TextField id = "outlined-filled" label = "Venmo Account" variant = "filled" value={venmo} onChange={(e) => setVenmo(e.target.value)}/>
             </EditPaymentOptions>
             <SubmitButton>
                 <Button
@@ -79,7 +56,7 @@ const ProfileForm = ({ onSubmit }) => {
                         firstName,
                         lastName,
                         phone,
-                        payment: { [paymentOption]: paymentAccount }
+                        venmo,
                         });
                     }}
                 >


### PR DESCRIPTION
# Description

Removes everything but Venmo as discussed in the 19 Jan scrum. The Venmo field is optional.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

1. Logout
2. Delete your user from the backend
3. Login
4. Fill the onboarding form, including the payment option
5. Navigate to the profile page
    - Confirm that the Venmo ID is correct
    - Confirm that clicking on the Venmo ID copies it to the clipboard
6. Repeat 1–3
7. Fill the onboarding form with no payment option
8. Navigate to the profile page
    - Confirm that the lack of Venmo ID is clearly indicated
    - Confirm that clicking on the Venmo ID doesn't change your clipboard and shows visual feedback explaining why