### PR TITLE
remove WRC from list of locations

### DIFF
--- a/client/src/Pages/Search/Form.js
+++ b/client/src/Pages/Search/Form.js
@@ -26,11 +26,6 @@ let PossibleLocations = [
     _id: "60dd1fff8211a44ac40b33f2",
     title: "IAH",
     address: "2800 N Terminal Rd, Houston, TX 77032, USA"
-  },
-  {
-    _id: "60dd20008211a44ac40b33f3",
-    title: "WRC",
-    address: "6330 Main St, Houston, TX 77005, USA"
   }];
 
   // May cause 401 error if a request is made to the database before it's ready


### PR DESCRIPTION
# Description

Removed WRC as a location. Now only Rice, HOU, and IAH exist.

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Go to search page. Open the departure location and destination dropdowns and confirm that WRC is no longer an option.
