### PR TITLE
Fix rider list clipping

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -198,7 +198,7 @@ const RideSummary = () => {
           <LineDiv>
             <hr></hr>
           </LineDiv>
-          {ride.riders.slice(0, 3).map((person) => (
+          {ride.riders.map((person) => (
             <div onClick={e => history.push("/profile/" + person.netid)}>
               <OneRiderContainer>
                 <div key={person.netid}>


### PR DESCRIPTION
# Description

When a ride had more than three riders (including the host), only three of them would show up in the list on the ride summary page. This fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Create a new ride with like 7 spots
- Have four or more users join the ride (or simulate that by fiddling with the DB)
- Confirm that all users are listed on the ride summary page