### PR TITLE
Removed duplicate host from riders list in RideSummary

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -198,7 +198,7 @@ const RideSummary = () => {
           <LineDiv>
             <hr></hr>
           </LineDiv>
-          {ride.riders.slice(0, 3).map((person) => (
+          {ride.riders.filter((x) => x.firstName + " " + x.lastName != ride.owner.firstName + " " + ride.owner.lastName).map((person) => (
             <div onClick={e => history.push("/profile/" + person.netid)}>
               <OneRiderContainer>
                 <div key={person.netid}>


### PR DESCRIPTION
# Description
Fixed issue where host would appear in the list of current riders for RideSummary, creating a duplicated user. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Evaluated no duplicate present by visiting each ride and testing that only one instance of the host is present on the RideSummary page.