### PR TITLE
Fixed seats left bug b/w search + rideSummary pages

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -141,7 +141,7 @@ const RideSummary = () => {
       </BackArrowDiv>
       <RideSummaryDiv>
         <SeatsLeftDiv>
-          <SeatsLeftNum>{(ride.spots - ride.riders.length) + 1}</SeatsLeftNum>
+          <SeatsLeftNum>{(ride.spots - ride.riders.length)}</SeatsLeftNum>
           <SeatsLeftText>seat(s) <br/>left</SeatsLeftText>
           <SocialIcon>
             <IoShareSocialSharp></IoShareSocialSharp>

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -141,7 +141,7 @@ const RideSummary = () => {
       </BackArrowDiv>
       <RideSummaryDiv>
         <SeatsLeftDiv>
-          <SeatsLeftNum>{ride.spots}</SeatsLeftNum>
+          <SeatsLeftNum>{(ride.spots - ride.riders.length) + 1}</SeatsLeftNum>
           <SeatsLeftText>seat(s) <br/>left</SeatsLeftText>
           <SocialIcon>
             <IoShareSocialSharp></IoShareSocialSharp>

--- a/client/src/Pages/Search/Ride.js
+++ b/client/src/Pages/Search/Ride.js
@@ -24,7 +24,7 @@ const Ride = ({ride}) => {
                 <Grid item xs={3} justify="center" align='center' style={{display: 'flex', placeItems: 'center'}}>
                     
                         <Box width={"60%"} height={"75%"} style={{display: 'flex', flexDirection: 'column', backgroundColor: 'rgba(187, 218, 255, 0.22)', borderRadius: '5px', justifyContent: 'center'}}>
-                            <span style={{fontSize: '4vw', fontFamily: 'Josefin Sans'}}>{(ride.spots - ride.riders.length) + 1}</span>
+                            <span style={{fontSize: '4vw', fontFamily: 'Josefin Sans'}}>{(ride.spots - ride.riders.length)}</span>
                             <span style={{fontSize: '2.5vw', fontFamily: 'Josefin Sans'}}>seats left</span>  
                         </Box>
                 </Grid>

--- a/client/src/Pages/Search/Ride.js
+++ b/client/src/Pages/Search/Ride.js
@@ -24,7 +24,7 @@ const Ride = ({ride}) => {
                 <Grid item xs={3} justify="center" align='center' style={{display: 'flex', placeItems: 'center'}}>
                     
                         <Box width={"60%"} height={"75%"} style={{display: 'flex', flexDirection: 'column', backgroundColor: 'rgba(187, 218, 255, 0.22)', borderRadius: '5px', justifyContent: 'center'}}>
-                            <span style={{fontSize: '4vw', fontFamily: 'Josefin Sans'}}>{ride.spots}</span>
+                            <span style={{fontSize: '4vw', fontFamily: 'Josefin Sans'}}>{(ride.spots - ride.riders.length) + 1}</span>
                             <span style={{fontSize: '2.5vw', fontFamily: 'Josefin Sans'}}>seats left</span>  
                         </Box>
                 </Grid>


### PR DESCRIPTION
# Description
Seats left for a ride differed between search and rideSummary pages. Incorrectly displayed ride capacity as opposed to the number of seats left. Formula to calculate seats left is now (ride.spots - ride.riders.length)
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Verified number of riders left was the same on RideSummary page + Search page for each ride.
