### PR TITLE
Fix open seat limit and view

### DIFF
--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -285,7 +285,7 @@ const Create = ({onCreate}) => {
                 >
                     <FormControlLabelBox
                         control={<CheckBox color='primary' checked={confirmation} onChange={onCheck}/>}
-                        label="I will be responsible for coordinating this ride."
+                        label="I am responsible for coordinating this ride."
                     />
                 </Grid>
 

--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -274,7 +274,7 @@ const Create = ({onCreate}) => {
                         </SelectSquare> 
                     </Grid>
                     <Grid item>
-                        <BodyText>{"# of open seats"}</BodyText> 
+                        <BodyText>{"# of seats (include yourself)"}</BodyText> 
                     </Grid>
 
                 </Grid>

--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -31,6 +31,12 @@ const Create = ({onCreate}) => {
 
     const seats = [
         {
+            value: 2
+        }, 
+        {
+            value: 3
+        }, 
+        {
             value: 4
         }, 
         {
@@ -38,12 +44,6 @@ const Create = ({onCreate}) => {
         }, 
         {
             value: 6
-        }, 
-        {
-            value: 7
-        }, 
-        {
-            value: 8
         }
     ]
 
@@ -51,7 +51,7 @@ const Create = ({onCreate}) => {
     const [startLoc, setStartLoc] = useState('')
     const [endLoc, setEndLoc] = useState('')
     const [date, setDate] = useState(new Date())
-    const [passengers, setPassengers] = useState(4)
+    const [passengers, setPassengers] = useState(3)
     const [confirmation, setConfirmation] = useState(false)
 
     // Function after Submit Button is Pressed

--- a/client/src/Pages/CreateRide/Create.styles.js
+++ b/client/src/Pages/CreateRide/Create.styles.js
@@ -161,7 +161,7 @@ export const ColorButton = withStyles({
     font-family: Josefin Sans;
     font-style: normal;
     font-weight: normal;
-    font-size: 2vh;
+    font-size: 1.75vh;
     line-height: 2vh;
     color: #0B3669;
     padding: 10px 0px 0px 0px;


### PR DESCRIPTION
[](url)# Description

- Adjust the seating options from {4, 5, 6, 7, 8} to {2, 3 , 4, 5, 6} 
- Changed the wording of "# of open seats" to "# of seats (include yourself) with adjusted font size
- Changed "I will be responsible for coordinating this ride" to "I am responsible for coordinating this ride" to avoid an awkard "ride" word by itself starting a second line on certain phone screens

## Type of change

- [ X] Style Change

# How Has This Been Tested?

It looks right! 

<img width="195" alt="Screen Shot 2022-01-26 at 9 27 57 PM" src="https://user-images.githubusercontent.com/53880607/151286899-e4f57e43-e541-4f9e-ae98-dbd7dec354b8.png">

<img width="197" alt="Screen Shot 2022-01-26 at 9 29 10 PM" src="https://user-images.githubusercontent.com/53880607/151286980-5dd08574-ab92-4df3-be3b-6574984998d9.png">


Let A be an element that looks like a duck, quack like a duck, and walk like a duck => A is a duck. 


