### PR TITLE
Disable 'Join Ride' button when ride's full

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -232,7 +232,9 @@ const RideSummary = () => {
         </RidersComponents>
       </RidersDiv>
       <ButtonContainer>
-        <ButtonDiv onClick={join}>Join Ride</ButtonDiv>
+        <ButtonDiv onClick={join} disabled={ride.spots === ride.riders.length}>
+          Join Ride
+        </ButtonDiv>
       </ButtonContainer>
     </AllDiv>
   )

--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -1,5 +1,5 @@
 import LocationOn from '@material-ui/icons/LocationOn'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 const SeatsLeftDiv = styled.div`
   grid-column: 4;

--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -1,5 +1,5 @@
 import LocationOn from '@material-ui/icons/LocationOn'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 const SeatsLeftDiv = styled.div`
   grid-column: 4;
@@ -199,7 +199,7 @@ const TextContainer = styled.div`
 `
 const ButtonDiv = styled.button`
   color: #ffffff;
-  background: #2075d8;
+  background: ${({ disabled }) => !disabled ? '#2075d8' : '#9e9e9e'};
   text-align: center;
   font-family: Josefin Sans;
   font-style: normal;
@@ -209,7 +209,7 @@ const ButtonDiv = styled.button`
   border-radius: 8px;
   width: 100%;
   height: 48px;
-  cursor: pointer;
+  cursor: ${({ disabled }) => !disabled ? 'pointer' : 'inherit'};
   onclick='joinRide()';
   
 `


### PR DESCRIPTION
# Description

When a ride's full, the Join Ride button should look like it's disabled, instead of inviting a click with its bright `#2075d8` hue.

![Mouse hovering over a disabled "Join Ride" button](https://user-images.githubusercontent.com/11537232/152268036-70cfb87a-611a-400f-8748-6cb3286b8d61.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I was unfortunately unable to properly test this, so beware.

Please include:
- Create a ride
- Have people join until it's full (or simulate through db-fiddling)
- Confirm that the button visibly indicates a disabled state
- Confirm that clicking the button shows an error toast (courtesy #95)
