### PR TITLE
Removed the intial date and an unused today's date variable

### DIFF
--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -46,14 +46,13 @@ const FormOnly = (props) => {
 
   const displayRef = props.displayRef;
 
-  const todayDate = new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
   const minDate = new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
   
   const [startLoc, setStartLoc] = useState('')
   const [endLoc, setEndLoc] = useState('')
 
   // state for filter date
-  const [filterDate, setfilterDate] = useState(todayDate);
+  const [filterDate, setfilterDate] = useState(null);
 
   const [numberPeople, setNumberPeople] = useState(null)
 


### PR DESCRIPTION
# Description

Removed today's date on the Search page. Small Change. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No breaking changes on the page. Filter works properly. 
