### PR TITLE
Added flexible back button

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -178,7 +178,7 @@ const RideSummary = () => {
     <AllDiv>
       <BackArrowDiv onClick={() => goBack()}>
         <BackArrow></BackArrow>
-        <BackText>{localStorage.getItem("lastPage") === "your-rides" ? "Your Ride" : "Search"}</BackText>
+        <BackText>{localStorage.getItem("lastPage") === "your-rides" ? "Your Rides" : "Search"}</BackText>
       </BackArrowDiv>
 
       <RideSummaryDiv>

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -157,16 +157,16 @@ const RideSummary = () => {
   if (!data) return <p>No data...</p>
 
  
-
   const goBack = () => {
     let lastPage = '/' + localStorage.getItem('lastPage');
     localStorage.setItem('lastPage', `ridesummary/${id}`);
     // Any attempts to go back to edit the onboarding form
     // should take you back to the current ride summary page.
-    if (lastPage === "/onboarding"){
-      localStorage.setItem('nextPage', `ridesummary/${id}`); 
+    if (lastPage === "/your-rides"){
+      history.push(lastPage);
+    } else {
+      history.push("/search");
     }
-    history.push(lastPage);
   }
 
   const time = moment(ride.departureDate)
@@ -178,7 +178,7 @@ const RideSummary = () => {
     <AllDiv>
       <BackArrowDiv onClick={() => goBack()}>
         <BackArrow></BackArrow>
-        <BackText>Search Page</BackText>
+        <BackText>{localStorage.getItem("lastPage") === "your-rides" ? "Your Ride" : "Search"}</BackText>
       </BackArrowDiv>
 
       <RideSummaryDiv>

--- a/client/src/Pages/YourRides/UpcomingRideCard.js
+++ b/client/src/Pages/YourRides/UpcomingRideCard.js
@@ -49,6 +49,7 @@ const CalendarIcon = withStyles({
   })(NotificationsOffIcon);
 
 
+
 const UpcomingRideCard = ({id, origin, destination, datetime, notification}) => {
 
     const time = moment(datetime)
@@ -58,8 +59,13 @@ const UpcomingRideCard = ({id, origin, destination, datetime, notification}) => 
     const history = useHistory();
     const summaryURL = "/ridesummary/" + id;
 
+    const toRide = (url) => {
+        localStorage.setItem("lastPage", "your-rides");
+        history.push(url);
+    }
+
     return (
-        <div onClick={e => history.push(summaryURL)}>
+        <div onClick={(e) => toRide(summaryURL)}>
             <RideCard>
                 <RideTimeInfo>
                     <CalendarIcon />


### PR DESCRIPTION
# Description

The back button in ride summary is now conditional on the last page. If the last page visited is "your-rides", then the button displays "< Your Rides" and routes back to the user's rides page. Else, the back button will display "< Search" and route back to that page in all other cases. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested this flow by pressing the back button in the following cases: 

- As a registered user going to search, clicking on a ride card, and then going back. Button displays "< Search" and the user is expected to be back in the search page.
- As a registered user going first to "Your Rides", clicking on a ride card, and then pressing back. Button displays "< Your Rides" and the user is expected to be back in the your rides page.
- I have attempted to join a Ride as an unregistered user, arriving at onboarding form, then in ride summary. Button displays "< Search" and the user is expected to be back in the search page.