### PR TITLE
Improve desktop styles

### DIFF
--- a/client/src/Pages/YourRides/PastRideCard.styles.js
+++ b/client/src/Pages/YourRides/PastRideCard.styles.js
@@ -7,9 +7,8 @@ grid-template-columns: 65% 35%;
 background: #FFFFFF;
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
-height: 10vh;
-margin-top: 2vh;
-margin-bottom: 2vh;
+margin-top: 2em;
+margin-bottom: 2em;
 `;
 
 const PaidPastRide = styled.div`
@@ -19,17 +18,15 @@ grid-template-columns: 65% 35%;
 background: rgba(187, 218, 255, 0.22);
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
-height: 10vh;
-margin-top: 2vh;
-margin-bottom: 2vh;
+margin-top: 2em;
+margin-bottom: 2em;
 `;
 
 const PastRideCardData = styled.div`
 display: grid;
 grid-column-start: 1;
-max-height: 10vh;
-margins: 5%;
-padding: 3%;
+margins: 5px;
+padding: 3px;
 grid-template-columns: 30% 70%;
 `
 
@@ -50,20 +47,19 @@ const RideDate = styled.div`
 font-family: Josefin Sans;
 font-style: normal;
 font-weight: normal;
-font-size: 2.5vh;
+font-size: 1rem;
 `
 
 const RideTime = styled.div`
 font-family: Josefin Sans;
 font-style: normal;
 font-weight: 300;
-font-size: 2vh;
+font-size: 1rem;
 `;
 
 const Locations = styled.div`
 font-family: Josefin Sans;
 padding: 10%;
-max-height: 10vh;
 grid-column-start: 2;
 display: flex;
 justify-content: space-between;
@@ -72,13 +68,12 @@ align-items: center;
 `
 
 const LocationText = styled.div`
-font-size: 3vh;
+font-size: 1rem;
 font-family: Josefin Sans;
 `
 
 const PaidPaymentInfo = styled.div`
 grid-column-start: 2;
-max-height: 10vh;
 display: flex;
 background: #BBDAFF;
 justify-content: space-between;
@@ -90,7 +85,6 @@ padding: 10%;
 const UnpaidPaymentInfo = styled.div`
 grid-column-start: 2;
 display: flex;
-max-height: 10vh;
 background: #EB5248;
 justify-content: space-between;
 align-items: center;
@@ -98,7 +92,7 @@ border-radius: 0px 9px 9px 0px;
 padding: 10%;
 `
 const PaymentText = styled.div`
-font-size: 2vh;
+fornt-size: 2em;
 font-family: Josefin Sans;
 font-style: normal;
 font-weight: normal;

--- a/client/src/Pages/YourRides/PastRideCard.styles.js
+++ b/client/src/Pages/YourRides/PastRideCard.styles.js
@@ -7,8 +7,7 @@ grid-template-columns: 65% 35%;
 background: #FFFFFF;
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
-margin-top: 2em;
-margin-bottom: 2em;
+margin: 1em 0;
 `;
 
 const PaidPastRide = styled.div`
@@ -18,8 +17,7 @@ grid-template-columns: 65% 35%;
 background: rgba(187, 218, 255, 0.22);
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
-margin-top: 2em;
-margin-bottom: 2em;
+margin: 1em 0;
 `;
 
 const PastRideCardData = styled.div`
@@ -38,8 +36,8 @@ justify-content: space-between;
 align-items: center;
 flex-direction: column;
 border-radius: 9px;
-padding-top: 20%;
-padding-bottom: 20%;
+padding-top: 1em;
+padding-bottom: 1em;
 
 `;
 
@@ -59,7 +57,7 @@ font-size: 1rem;
 
 const Locations = styled.div`
 font-family: Josefin Sans;
-padding: 10%;
+padding: 1em;
 grid-column-start: 2;
 display: flex;
 justify-content: space-between;
@@ -79,7 +77,7 @@ background: #BBDAFF;
 justify-content: space-between;
 align-items: center;
 border-radius: 0px 9px 9px 0px;
-padding: 10%;
+padding: 1em;
 `;
 
 const UnpaidPaymentInfo = styled.div`
@@ -89,7 +87,7 @@ background: #EB5248;
 justify-content: space-between;
 align-items: center;
 border-radius: 0px 9px 9px 0px;
-padding: 10%;
+padding: 1em;
 `
 const PaymentText = styled.div`
 fornt-size: 2em;

--- a/client/src/Pages/YourRides/UpcomingRideCard.styles.js
+++ b/client/src/Pages/YourRides/UpcomingRideCard.styles.js
@@ -7,10 +7,7 @@ grid-template-columns: 30% 60% 10%;
 background: #FFFFFF;
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
-height: 15vh;
-padding: 1vh;
-margin-top: 2vh;
-margin-bottom: 2vh;
+margin: 1em 0;
 `;
 
 
@@ -22,8 +19,8 @@ justify-content: space-between;
 align-items: center;
 flex-direction: column;
 border-radius: 9px;
-padding-top: 20%;
-padding-bottom: 20%;
+padding-top: 1em;
+padding-bottom: 1em;
 `
 
 const RideDate = styled.div`
@@ -42,7 +39,7 @@ font-size: 2vh;
 
 const Locations = styled.div`
 font-family: Josefin Sans;
-padding: 10%;
+padding: 1em;
 grid-column-start: 2;
 display: flex;
 justify-content: space-between;

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
     width: "66vw",
     height: "100vh",
-    maxWidth: 300,
+    maxWidth: 350,
   },
   usernameContainer:{
     gap: "5vw",
@@ -50,9 +50,10 @@ const useStyles = makeStyles((theme) => ({
 const LogInOutButton = withStyles({
   root: {
       background: '#2075D8',
-      width: '33vw',
+      width: '100%',
       borderRadius: 25,
       color: 'white',
+      margin: '0 1em',
   },
   label: {
     textTransform: 'capitalize',

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -34,6 +34,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
     width: "66vw",
     height: "100vh",
+    maxWidth: 300,
   },
   usernameContainer:{
     gap: "5vw",


### PR DESCRIPTION
# Description

Makes the 'Your Rides' page and the sidebar look less "whacky" [sic] on desktop.

<img src="https://user-images.githubusercontent.com/11537232/154814220-080b5bd4-965b-4561-9855-9e84be5a4369.png" alt="The Your Rides page in a desktop-sized viewport" width="350" /> <img src="https://user-images.githubusercontent.com/11537232/154814223-9d486a52-730a-4299-8000-d7a925e8b3ea.png" alt="The sidebar opened on the Your Rides page in a desktop-sized viewport" width="350" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to make sure that this doesn't break styles on mobile, but it could use another pair of eyes.