### PR TITLE
Ride Summary Filter by NetID

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -240,7 +240,7 @@ const RideSummary = () => {
           <LineDiv>
             <hr></hr>
           </LineDiv>
-          {ride.riders.filter((x) => x.firstName + " " + x.lastName !== ride.owner.firstName + " " + ride.owner.lastName).map((person) => (
+          {ride.riders.filter((x) => x.netid !== ride.owner.netid).map((person) => (
             <div onClick={e => history.push("/profile/" + person.netid)}>
               <OneRiderContainer>
                 <div key={person.netid}>


### PR DESCRIPTION
# Description

Changed the ride summary page filtering by first and last name such that two individuals with the same name joining the same ride will still both show up

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Let two people with the same first and last name join the same and they both showed up! (Mitchell and Kai both with "Kai Hung" as their name)
