### PR TITLE
Bell and payment removal in "Your Rides"

### DIFF
--- a/client/src/Pages/YourRides/PastRideCard.js
+++ b/client/src/Pages/YourRides/PastRideCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
-import PriorityHighIcon from '@material-ui/icons/PriorityHigh';
-import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
+// import PriorityHighIcon from '@material-ui/icons/PriorityHigh';
+// import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
 import moment from 'moment';
 import { useHistory } from 'react-router';
 
@@ -25,23 +25,23 @@ import {
   const ArrowForward = withStyles({
   })(ArrowForwardIcon);
 
-  const UnpaidIcon = withStyles({
-    root: {
-        display: 'flex',
-        color: '#FFFFFF',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }
-  })(PriorityHighIcon);
+//   const UnpaidIcon = withStyles({
+//     root: {
+//         display: 'flex',
+//         color: '#FFFFFF',
+//         justifyContent: 'center',
+//         alignItems: 'center'
+//       }
+//   })(PriorityHighIcon);
 
-  const PaidIcon = withStyles({
-    root: {
-        display: 'flex',
-        color: '#FFFFFF',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }
-  })(AttachMoneyIcon);
+//   const PaidIcon = withStyles({
+//     root: {
+//         display: 'flex',
+//         color: '#FFFFFF',
+//         justifyContent: 'center',
+//         alignItems: 'center'
+//       }
+//   })(AttachMoneyIcon);
 
 
 const PastRideCard = ({id, origin, destination, datetime, paid}) => {

--- a/client/src/Pages/YourRides/PastRideCard.js
+++ b/client/src/Pages/YourRides/PastRideCard.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { useHistory } from 'react-router';
 
 import { 
-    UnpaidPastRide,
+    // UnpaidPastRide,
 	PaidPastRide,
     PastRideCardData,
 	RideTimeInfo,
@@ -15,9 +15,10 @@ import {
 	RideTime,
 	Locations,
     LocationText,
-	PaidPaymentInfo,
-	UnpaidPaymentInfo,
-	PaymentText } 
+	// PaidPaymentInfo,
+	// UnpaidPaymentInfo,
+	// PaymentText 
+} 
     from './PastRideCard.styles.js';
 
 
@@ -78,30 +79,28 @@ const PastRideCard = ({id, origin, destination, datetime, paid}) => {
 
     return (
         <div>
-            { paid ? 
+            {/* { paid ?  */}
         
             <PaidPastRide>
                 <RideCardData />
-                <PaidPaymentInfo>
+                {/* <PaidPaymentInfo>
                     <PaidIcon />
                     <PaymentText>Payment Complete</PaymentText>
-                </PaidPaymentInfo>
+                </PaidPaymentInfo> */}
             </PaidPastRide>
 
-            :
-
-            <UnpaidPastRide>
-                <RideCardData />
-                <UnpaidPaymentInfo>
-                    <UnpaidIcon />
-                    <PaymentText>Payment Incomplete</PaymentText>
-                </UnpaidPaymentInfo>
-            </UnpaidPastRide>
-            }
+            {/* : */}
+{/* 
+             <UnpaidPastRide>
+                 <RideCardData />
+                 <UnpaidPaymentInfo>
+                     <UnpaidIcon />
+                     <PaymentText>Payment Incomplete</PaymentText>
+                 </UnpaidPaymentInfo>
+             </UnpaidPastRide>
+             } */}
             
 
-
-            
         </div>
     )
 }

--- a/client/src/Pages/YourRides/PastRideCard.styles.js
+++ b/client/src/Pages/YourRides/PastRideCard.styles.js
@@ -1,19 +1,19 @@
 import styled from 'styled-components';
 
-const UnpaidPastRide = styled.div`
-display: grid;
-width: 90vw;
-grid-template-columns: 65% 35%;
-background: #FFFFFF;
-box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
-border-radius: 9px;
-margin: 1em 0;
-`;
+// const UnpaidPastRide = styled.div`
+// display: grid;
+// width: 90vw;
+// grid-template-columns: 65% 35%;
+// background: #FFFFFF;
+// box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
+// border-radius: 9px;
+// margin: 1em 0;
+// `;
 
 const PaidPastRide = styled.div`
 display: grid;
 width: 90vw;
-grid-template-columns: 65% 35%;
+grid-template-columns: 100% // FOR FUTURE WHEN WE HAVE PAID RIDES: 65% 35%;
 background: rgba(187, 218, 255, 0.22);
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
@@ -70,36 +70,36 @@ font-size: 1rem;
 font-family: Josefin Sans;
 `
 
-const PaidPaymentInfo = styled.div`
-grid-column-start: 2;
-display: flex;
-background: #BBDAFF;
-justify-content: space-between;
-align-items: center;
-border-radius: 0px 9px 9px 0px;
-padding: 1em;
-`;
+// const PaidPaymentInfo = styled.div`
+// grid-column-start: 2;
+// display: flex;
+// background: #BBDAFF;
+// justify-content: space-between;
+// align-items: center;
+// border-radius: 0px 9px 9px 0px;
+// padding: 1em;
+// `;
 
-const UnpaidPaymentInfo = styled.div`
-grid-column-start: 2;
-display: flex;
-background: #EB5248;
-justify-content: space-between;
-align-items: center;
-border-radius: 0px 9px 9px 0px;
-padding: 1em;
-`
-const PaymentText = styled.div`
-fornt-size: 2em;
-font-family: Josefin Sans;
-font-style: normal;
-font-weight: normal;
-color: #FFFFFF;
-`
+// const UnpaidPaymentInfo = styled.div`
+// grid-column-start: 2;
+// display: flex;
+// background: #EB5248;
+// justify-content: space-between;
+// align-items: center;
+// border-radius: 0px 9px 9px 0px;
+// padding: 1em;
+// `
+// const PaymentText = styled.div`
+// fornt-size: 2em;
+// font-family: Josefin Sans;
+// font-style: normal;
+// font-weight: normal;
+// color: #FFFFFF;
+// `
 
 
 export {
-	UnpaidPastRide,
+	// UnpaidPastRide,
 	PaidPastRide,
 	PastRideCardData,
 	RideTimeInfo,
@@ -107,7 +107,7 @@ export {
 	RideTime,
 	LocationText,
 	Locations,
-	PaidPaymentInfo,
-	UnpaidPaymentInfo,
-	PaymentText
+	// PaidPaymentInfo,
+	// UnpaidPaymentInfo,
+	// PaymentText
 };

--- a/client/src/Pages/YourRides/UpcomingRideCard.js
+++ b/client/src/Pages/YourRides/UpcomingRideCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
-import NotificationsActiveIcon from '@material-ui/icons/NotificationsActive';
-import NotificationsOffIcon from '@material-ui/icons/NotificationsOff';
+// import NotificationsActiveIcon from '@material-ui/icons/NotificationsActive';
+// import NotificationsOffIcon from '@material-ui/icons/NotificationsOff';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import moment from 'moment';
 import { useHistory } from 'react-router';
@@ -14,7 +14,8 @@ import {
     RideTime, 
     LocationText, 
     Locations, 
-    Notifications } 
+    // Notifications 
+} 
     from './UpcomingRideCard.styles.js';
 
 const CalendarIcon = withStyles({
@@ -29,24 +30,24 @@ const CalendarIcon = withStyles({
   const ArrowForward = withStyles({
   })(ArrowForwardIcon);
 
-  const NotificationsOn = withStyles({
-    root: {
-        display: 'flex',
-        color: '#2075D8',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }
+//   const NotificationsOn = withStyles({
+//     root: {
+//         display: 'flex',
+//         color: '#2075D8',
+//         justifyContent: 'center',
+//         alignItems: 'center'
+//       }
  
-  })(NotificationsActiveIcon);
+//   })(NotificationsActiveIcon);
   
-  const NotificationsOff = withStyles({
-    root: {
-        display: 'flex',
-        color: 'rgba(32, 117, 216, 0.42)',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }
-  })(NotificationsOffIcon);
+//   const NotificationsOff = withStyles({
+//     root: {
+//         display: 'flex',
+//         color: 'rgba(32, 117, 216, 0.42)',
+//         justifyContent: 'center',
+//         alignItems: 'center'
+//       }
+//   })(NotificationsOffIcon);
 
 
 
@@ -83,9 +84,9 @@ const UpcomingRideCard = ({id, origin, destination, datetime, notification}) => 
                     <LocationText>{ destination }</LocationText>
                 </Locations>
 
-                <Notifications>
+                {/* <Notifications>
                     { notification ? <NotificationsOn /> : <NotificationsOff /> }
-                </Notifications>
+                </Notifications> */}
             </RideCard>
         </div>
     )

--- a/client/src/Pages/YourRides/UpcomingRideCard.styles.js
+++ b/client/src/Pages/YourRides/UpcomingRideCard.styles.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const RideCard = styled.div`
 display: grid;
 width: 100%;
-grid-template-columns: 30% 60% 10%;
+grid-template-columns: 35% 65%; // FOR FUTURE USE WHEN WE HAVE NOTIFICATIONS: 10%;
 background: #FFFFFF;
 box-shadow: 3px 3px 12px -1px rgba(187, 218, 255, 0.98);
 border-radius: 9px;
@@ -52,9 +52,9 @@ font-size: 3vh;
 font-family: Josefin Sans;
 `
 
-const Notifications = styled.div`
-grid-column-start: 3;
-`
+// const Notifications = styled.div`
+// grid-column-start: 3;
+// `
 
 export {
 	RideCard,
@@ -63,5 +63,5 @@ export {
 	RideTime,
 	LocationText,
 	Locations,
-	Notifications
+	// Notifications
 };

--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -101,7 +101,10 @@ const YourRides = (paid) => {
                 </UpcomingRidesSection>
 
                 <PastRidesSection>
-                    <PastRideTitle><TitleText>Past Rides</TitleText><TitleText>Payments</TitleText></PastRideTitle>
+                    <PastRideTitle>
+                        <TitleText>Past Rides</TitleText>
+                        {/* <TitleText>Payments</TitleText> */}
+                    </PastRideTitle>
                     {prevRides.map(ride => {
                         return (
                             <PastRideCard 


### PR DESCRIPTION
# Description

Gets rid of the bell and payment icons in upcoming and past rides (respectively). They're commented out so that for future use, they can just be uncommented and we'd be good!

## Type of change

Please delete options that are not relevant.

- [ ] Removing the front end icons for features that have yet to be created.


# How Has This Been Tested?

Please include:
I haven't been able to test the bell icon because I'm unable to see upcoming rides.