### PR TITLE
Add create ride button after list of all matched rides

### DIFF
--- a/client/src/Pages/Search/DisplayRides.js
+++ b/client/src/Pages/Search/DisplayRides.js
@@ -87,7 +87,7 @@ const DisplayRides = (props) => {
                     </Box>
                 </Grid>
             }
-            <StyledButton style={{fontSize: "2vh", color:"white",  height: '100%', display: 'flex', borderRadius: '10px', backgroundColor:"#2075D8"}} onClick={() => handleClickCreateRide()}> 
+            <StyledButton variant="outlined" style={{fontSize: "2vh", color:"#2075D8",  height: '100%', display: 'flex', borderRadius: '10px'}} onClick={() => handleClickCreateRide()}> 
                     Don't see a match? Create a new ride 
             </StyledButton>
             {

--- a/client/src/Pages/Search/DisplayRides.js
+++ b/client/src/Pages/Search/DisplayRides.js
@@ -87,7 +87,7 @@ const DisplayRides = (props) => {
                     </Box>
                 </Grid>
             }
-            <StyledButton variant="outlined" style={{fontSize: "2vh", color:"#2075D8",  height: '100%', display: 'flex', borderRadius: '10px'}} onClick={() => handleClickCreateRide()}> 
+            <StyledButton style={{fontSize: "2vh", color:"#2075D8",  height: '100%', display: 'flex', borderRadius: '10px'}} onClick={() => handleClickCreateRide()}> 
                     Don't see a match? Create a new ride 
             </StyledButton>
             {

--- a/client/src/Pages/Search/DisplayRides.js
+++ b/client/src/Pages/Search/DisplayRides.js
@@ -87,8 +87,11 @@ const DisplayRides = (props) => {
                     </Box>
                 </Grid>
             }
+            <StyledButton style={{fontSize: "2vh", color:"white",  height: '100%', display: 'flex', borderRadius: '10px', backgroundColor:"#2075D8"}} onClick={() => handleClickCreateRide()}> 
+                    Don't see a match? Create a new ride 
+            </StyledButton>
             {
-                <div style = {{paddingTop: '4vh', fontSize: "4vh", fontFamily: "Josefin Sans"}}>All Rides:</div>
+                <div style = {{paddingTop: '1vh', fontSize: "4vh", fontFamily: "Josefin Sans"}}>All Rides:</div>
             }
             {
                 props.ridesPossible.filter((ride) => { return !ridesT.some(e => isEqualRides(ride, e))}).map((ride, ind) => (<Ride ride={ride} />))

--- a/client/src/Pages/Search/DisplayRides.js
+++ b/client/src/Pages/Search/DisplayRides.js
@@ -87,8 +87,8 @@ const DisplayRides = (props) => {
                     </Box>
                 </Grid>
             }
-            <StyledButton style={{fontSize: "2vh", color:"#2075D8",  height: '100%', display: 'flex', borderRadius: '10px'}} onClick={() => handleClickCreateRide()}> 
-                    Don't see a match? Create a new ride 
+            <StyledButton style={{fontSize: "1em", color:"#2075D8",  height: '100%', display: 'flex', borderRadius: '10px'}} onClick={() => handleClickCreateRide()}> 
+                    <p> Don't see a match? </p> &nbsp; Create a new ride 
             </StyledButton>
             {
                 <div style = {{paddingTop: '1vh', fontSize: "4vh", fontFamily: "Josefin Sans"}}>All Rides:</div>

--- a/client/src/Pages/Search/DisplayRides.styles.js
+++ b/client/src/Pages/Search/DisplayRides.styles.js
@@ -17,8 +17,12 @@ export const BoxRide = styled(Box)({
 
 export const StyledButton = withStyles({
     root: {
-        fontSize: "2.5vh"
-    },
+        fontSize: "2.5vh",
+        '& p' : {
+            color: "black",
+            fontFamily: "Josefin Sans"
+        }
+    },  
     label: {
         fontFamily: "Josefin Sans",
         textTransform: "none",

--- a/client/src/Pages/Search/Ride.js
+++ b/client/src/Pages/Search/Ride.js
@@ -36,7 +36,7 @@ const Ride = ({ride}) => {
     const date = new Date(ride.departureDate);
 
     return (
-        <Link href={`/ridesummary/${ride._id}`} style={{textDecoration: 'none'}}>
+        <Link href={`/ridesummary/${ride._id}`} style={{textDecoration: 'none', color:'#002140' }}>
         <Grid container key={ride._id} xs={12} alignItems='stretch' style={{height: '100%', width: "90vw", display: 'flex', borderRadius: '10px'}}>
             <Grid item container  style={{height:"16vh", backgroundColor: "white", borderRadius: '10px', borderColor:'', boxShadow: '0px 3px 10px #bbdaff'}}>
                 <Grid item xs={3} justify="center" align='center' style={{display: 'flex', placeItems: 'center'}}> 


### PR DESCRIPTION
# Description

Added a button/link that routes to the /create-ride after the list of matched rides.
Also changed the color of the ride text back to black.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="683" alt="image" src="https://user-images.githubusercontent.com/65870703/155275828-86d10e7b-98ba-40fe-8c26-6163b3ea9461.png">

