### PR TITLE
Added filter for full rides

### DIFF
--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -30,9 +30,10 @@ const FormOnly = (props) => {
     props.getRidesRefetch()
     .then((res) => {
 
-      const ridesPossibleNotBefore = res.data.rideMany.filter((ride) => {
+      var ridesPossibleNotBefore = res.data.rideMany.filter((ride) => {
         const rideDateAfterCurrentDate = compareDates(new Date(ride.departureDate), currentDate, true);
-        return rideDateAfterCurrentDate;
+        const isNotFull = (ride.spots - ride.riders.length) > 0
+        return rideDateAfterCurrentDate && isNotFull;
       });
       
       setRidesPossibleForm(ridesPossibleNotBefore);


### PR DESCRIPTION
# Description

Adjust ride search page to not show rides that are full

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Go to the search page and ensure no rides say 0 seats left. Create a ride and make sure it shows up on the list.
