### PR TITLE
Updated nav bar (feb 24)

### DIFF
--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -61,11 +61,15 @@ const useStyles = makeStyles((theme) => ({
   },
   usernameContainer:{
     gap: "5vw",
+    paddingLeft: '24px',
+    paddingRight: '24px',
     height: "15vh"
   },
   logInOutContainer:{
     display:"flex", 
-    justifyContent:"center", 
+    justifyContent:"center",
+    paddingLeft: '24px',
+    paddingRight: '24px', 
     height: "15vh",
   },
 }));

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -3,7 +3,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/MenuRounded';
 import HomeIcon from '@material-ui/icons/HomeRounded';
 import CarIcon from '@material-ui/icons/DirectionsCarRounded';
-import InfoIcon from '@material-ui/icons/PeopleRounded';
+import InfoIcon from '@material-ui/icons/EmojiPeopleRounded';
 import { List, ListItem, ListItemIcon, ListItemText, 
   Drawer, IconButton, AppBar, Toolbar, Avatar, Button, Divider } from '@material-ui/core';
 import { Link, useLocation } from 'react-router-dom'

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -39,6 +39,7 @@ const useStyles = makeStyles((theme) => ({
   },
   divider :{
     backgroundColor:"#BBDAFF",
+    margin: '1vh',
     height: '2px'
   },
   avatarIcon : {
@@ -183,7 +184,7 @@ export default function ButtonAppBar (props) {
           <ListItemIcon className = {classes.icon}> <CarIcon/> </ListItemIcon>
           <ListItemText classes = {classes.text} primary = "Your Rides"/>
         </ListItem>
-        <Divider variant="middle" className = {classes.divider}/>
+        <Divider variant="middle" classes = {{root: classes.divider}}/>
         <ListItem button className = {classes.item} component = {Link} to = "/about" onClick = {toggleDrawer}>
           <ListItemIcon className= {classes.icon}> <InfoIcon/> </ListItemIcon>
           <ListItemText  className = {classes.text} primary = "About Us"/>

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -3,7 +3,9 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/MenuRounded';
 import HomeIcon from '@material-ui/icons/HomeRounded';
 import CarIcon from '@material-ui/icons/DirectionsCarRounded';
-import InfoIcon from '@material-ui/icons/EmojiPeopleRounded';
+import InfoIcon from '@material-ui/icons/PeopleRounded';
+import MailIcon from '@material-ui/icons/MailRounded';
+import OpenInNewIcon from '@material-ui/icons/OpenInNewRounded';
 import { List, ListItem, ListItemIcon, ListItemText, 
   Drawer, IconButton, AppBar, Toolbar, Avatar, Button, Divider } from '@material-ui/core';
 import { Link, useLocation } from 'react-router-dom'
@@ -12,6 +14,7 @@ import { useEffect } from 'react';
 // SSO imports
 import { SERVICE_URL } from '../../config'; 
 const casLoginURL = 'https://idp.rice.edu/idp/profile/cas/login'; 
+const feedbackURL = 'https://forms.gle/WFqf77FxSy8FVHgb9'
 
 const useStyles = makeStyles((theme) => ({
   appbarRoot: {
@@ -20,8 +23,23 @@ const useStyles = makeStyles((theme) => ({
   icon: {
     color:"#002140",
   },
+  secondaryIcon:{
+    fontSize: 'medium',
+    color:"#BAC3CE"
+  },
+  item:{
+    height: '9vh',
+  },
   text : {
+    fontWeight: 'bold',
     color:"#002140",
+  },
+  disabledText : {
+    fontStyle: 'italic',
+  },
+  divider :{
+    backgroundColor:"#BBDAFF",
+    height: '2px'
   },
   avatarIcon : {
     width: "8vh",
@@ -129,6 +147,10 @@ export default function ButtonAppBar (props) {
     window.open(redirectURL, '_self');
   }
 
+  const openFeedback = () => {
+    window.open(feedbackURL, '_blank');
+  }
+
   const showUsername = (toggleDrawer) => (
     <ListItem button component = {Link} to = {"/profile/" + localStorage.getItem('netid')}  className={classes.usernameContainer} onClick = {toggleDrawer}>
       <Avatar className = {classes.avatarIcon}/>
@@ -137,7 +159,7 @@ export default function ButtonAppBar (props) {
   )
 
   const showLogin = (toggleDrawer) => (
-      <ListItem className={classes.logInOutContainer} divider = "true" disableGutters = "true">
+      <ListItem className={classes.logInOutContainer} disableGutters = "true">
         <LogInOutButton onClick = {() => {toggleDrawer(); login(); redirect();}}>Login</LogInOutButton>
       </ListItem>
   )
@@ -153,18 +175,23 @@ export default function ButtonAppBar (props) {
     <div>
       <List className = {classes.list}>
         {loggedIn ? showUsername(toggleDrawer) : showLogin(toggleDrawer)}
-        <ListItem button component = {Link} to = "/search" onClick = {toggleDrawer}>
+        <ListItem button  className = {classes.item} component = {Link} to = "/search" onClick = {toggleDrawer}>
           <ListItemIcon className= {classes.icon}> <HomeIcon/> </ListItemIcon>
           <ListItemText className = {classes.text} primary = "Home"/>
         </ListItem>
-        <ListItem button disabled = {!loggedIn} component = {Link} to = "/your-rides" onClick = {toggleDrawer}>
+        <ListItem button classes = {{root: classes.item, disabled: classes.disabledText}} disabled = {!loggedIn} component = {Link} to = "/your-rides" onClick = {toggleDrawer}>
           <ListItemIcon className = {classes.icon}> <CarIcon/> </ListItemIcon>
-          <ListItemText className = {classes.text} primary = "Your Rides"/>
+          <ListItemText classes = {classes.text} primary = "Your Rides"/>
         </ListItem>
-        <Divider/>
-        <ListItem button component = {Link} to = "/about" onClick = {toggleDrawer}>
+        <Divider variant="middle" className = {classes.divider}/>
+        <ListItem button className = {classes.item} component = {Link} to = "/about" onClick = {toggleDrawer}>
           <ListItemIcon className= {classes.icon}> <InfoIcon/> </ListItemIcon>
-          <ListItemText className = {classes.text} primary = "About"/>
+          <ListItemText  className = {classes.text} primary = "About Us"/>
+        </ListItem>
+        <ListItem button className = {classes.item} onClick = {openFeedback}>
+          <ListItemIcon className= {classes.icon}> <MailIcon/> </ListItemIcon>
+          <ListItemText classses = {classes.text} primary = "Give us feedback!"/> 
+          <OpenInNewIcon className= {classes.secondaryIcon}/> 
         </ListItem>
         {loggedIn ? showLogout(toggleDrawer) : null}
       </List>

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -3,8 +3,9 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/MenuRounded';
 import HomeIcon from '@material-ui/icons/HomeRounded';
 import CarIcon from '@material-ui/icons/DirectionsCarRounded';
+import InfoIcon from '@material-ui/icons/PeopleRounded';
 import { List, ListItem, ListItemIcon, ListItemText, 
-  Drawer, IconButton, AppBar, Toolbar, Avatar, Button } from '@material-ui/core';
+  Drawer, IconButton, AppBar, Toolbar, Avatar, Button, Divider } from '@material-ui/core';
 import { Link, useLocation } from 'react-router-dom'
 import { gql, useQuery} from "@apollo/client";
 import { useEffect } from 'react';
@@ -160,7 +161,9 @@ export default function ButtonAppBar (props) {
           <ListItemIcon className = {classes.icon}> <CarIcon/> </ListItemIcon>
           <ListItemText className = {classes.text} primary = "Your Rides"/>
         </ListItem>
-        <ListItem button className = {classes.bottomItem} component = {Link} to = "/about" onClick = {toggleDrawer}>
+        <Divider/>
+        <ListItem button component = {Link} to = "/about" onClick = {toggleDrawer}>
+          <ListItemIcon className= {classes.icon}> <InfoIcon/> </ListItemIcon>
           <ListItemText className = {classes.text} primary = "About"/>
         </ListItem>
         {loggedIn ? showLogout(toggleDrawer) : null}

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme) => ({
     zIndex:"999"
   },
   icon: {
+    minWidth: '40px',
     color:"#002140",
   },
   secondaryIcon:{
@@ -28,7 +29,9 @@ const useStyles = makeStyles((theme) => ({
     color:"#BAC3CE"
   },
   item:{
-    height: '9vh',
+    height: '8vh',
+    paddingLeft: '24px',
+    paddingRight: '24px'
   },
   text : {
     fontWeight: 'bold',
@@ -39,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
   },
   divider :{
     backgroundColor:"#BBDAFF",
-    margin: '1vh',
+    margin: '10px 30px 10px 30px',
     height: '2px'
   },
   avatarIcon : {


### PR DESCRIPTION
# Description
Updated the nav bar to current design spec:
- moved About us link and LogOut button from the bottom to the rest of the links;
- added link to feedback form; (should work!)
- changed spacing of navbar items

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Old nav bar:
<img width="548" alt="image" src="https://user-images.githubusercontent.com/65870703/155637765-4f7532f4-00cc-4c9e-a15c-063ebc74fbbe.png">
<img width="548" alt="image" src="https://user-images.githubusercontent.com/65870703/155637784-52280e26-0f8b-41fd-ba16-38c03d5c8b25.png">


New Nav Bar:
<img width="548" alt="image" src="https://user-images.githubusercontent.com/65870703/155637677-9f0a7b81-ff59-4dec-9cd6-9f6b721ec424.png">
<img width="548" alt="image" src="https://user-images.githubusercontent.com/65870703/155637700-eedfc0ac-dba7-46bc-b4c4-e317c7398166.png">
