### PR TITLE
Fix for Missing Your Rides Card as Non-Owner

### DIFF
--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -62,7 +62,7 @@ const YourRides = (paid) => {
                 if (ride.owner) {
                     ownerTrue = ride.owner.netid === netid
                 }
-                ride.riders.forEach(rider => riderTrue = rider.netid === netid)
+                ride.riders.forEach(rider => riderTrue = (riderTrue === true || rider.netid === netid))
                 return ownerTrue || riderTrue
             })
 


### PR DESCRIPTION
# Description

Found the issue. The logic for checking whether a user is part of a ride is flawed originally since the boolean variable was resetting in value for every rider.  So the check is only effective if the last rider in the `forEach` loop is the current user.  Added an extra condition to let the boolean value remain true if there is at least one true. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added myself to a ride created by Henry, didn't see it in the original version of your rides. Able to see it after the modification. 
