### PR TITLE
Force User Input of Name + Number

### DIFF
--- a/client/src/Pages/Onboarding/OnboardingForm.js
+++ b/client/src/Pages/Onboarding/OnboardingForm.js
@@ -19,6 +19,16 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
     const handleSubmit = (e) => {
         e.preventDefault();
 
+        if (firstName === "" || lastName === "") { 
+            addToast("Please fill in your full name.", { appearance: 'error' });
+            return
+        }   
+
+        if (phone === "") { 
+            addToast("Please fill in your phone number.", { appearance: 'error' });
+            return
+        }  
+
         return onSubmit({
             firstName, lastName,
             phone, venmo

--- a/client/src/Pages/Onboarding/OnboardingForm.js
+++ b/client/src/Pages/Onboarding/OnboardingForm.js
@@ -9,12 +9,15 @@ import {
   RequiredTextField
 } from "./OnboardingFormStyle.js";
 import React, { useState } from "react";
+import { useToasts } from "react-toast-notifications";
 
 const OnboardingForm = ({ onSubmit, onCancel }) => {
+    
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [phone, setPhone] = useState("");
   const [venmo, setVenmo] = useState(undefined);
+  const { addToast } = useToasts();
 
     const handleSubmit = (e) => {
         e.preventDefault();

--- a/client/src/Pages/Onboarding/OnboardingForm.js
+++ b/client/src/Pages/Onboarding/OnboardingForm.js
@@ -12,15 +12,16 @@ import React, { useState } from "react";
 import { useToasts } from "react-toast-notifications";
 
 const OnboardingForm = ({ onSubmit, onCancel }) => {
-    
+
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [phone, setPhone] = useState("");
   const [venmo, setVenmo] = useState(undefined);
   const { addToast } = useToasts();
 
-    const handleSubmit = (e) => {
-        e.preventDefault();
+    const handleSubmit = () => {
+
+        console.log(firstName);
 
         if (firstName === "" || lastName === "") { 
             addToast("Please fill in your full name.", { appearance: 'error' });
@@ -39,7 +40,7 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
     };
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form>
             <ProfileFormContainer>
                 <Header> Sign up to use Carpool</Header>
                 <InputBox>
@@ -78,20 +79,12 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
                 </InputBox>
                 <SubmitButton 
                     variant="contained"
-                    onClick={() => {
-                        onSubmit({
-                        firstName,
-                        lastName,
-                        phone,
-                        venmo,
-                        });
-                    }}>
+                    onClick={() => { handleSubmit()}}>
                         Submit
                 </SubmitButton>
                 <CancelButton
                     variant="contained"
-                    onClick={() => { onCancel()}
-                    }>
+                    onClick={() => { onCancel()}}>
                         Cancel
                 </CancelButton>
             </ProfileFormContainer>


### PR DESCRIPTION
# Description

The original code uses a submit form but no button was formally associated with a "submit" attribute. The default behavior after pressing the button is to adopt the `onSubmit` function passed into this component, which will jump straight to the GraphQL mutation. Incorporated a new function instead and added checks for different fields. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Let a new user attempts to onboard without first and last name. It won't allow them to complete the field and no mutations are made to the MongoDB in the background until those two fields are in fact filled out. 

<img width="305" alt="Screen Shot 2022-02-25 at 1 11 21 AM" src="https://user-images.githubusercontent.com/53880607/155671267-c28717a5-09ba-4d1f-968a-e4ea8c9a535c.png">
<img width="305" alt="Screen Shot 2022-02-25 at 1 11 36 AM" src="https://user-images.githubusercontent.com/53880607/155671281-1b80cf94-f9ca-4c82-a124-88dad38e67ca.png">

