### PR TITLE
Make phone number copyable

### DIFF
--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -88,7 +88,15 @@ const Profile = () => {
       <ProfileCard>
         <UserPic></UserPic>
         <UserName>{user.firstName + " " + user.lastName}</UserName>
-        <PhoneNumber>
+        <PhoneNumber onClick={async () => {
+            if (user.phone) {
+              navigator.clipboard.writeText(user.phone).then(
+                addToast("Phone Number Copied to Clipboard!", {
+                  appearance: "success",
+                })
+              );
+            }
+          }}>
           {user.phone ? user.phone : "Phone Number Unavailable"}
         </PhoneNumber>
         <TextBox

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -5,7 +5,7 @@ import { useToasts } from "react-toast-notifications";
 import ProfileDialog from "./ProfileDialog.js";
 import IconButton from "@material-ui/core/IconButton";
 import EditIcon from "@material-ui/icons/Edit";
-import FileCopyIcon from '@material-ui/icons/FileCopy';
+import PhoneIcon from '@material-ui/icons/PhoneInTalkOutlined';
 
 import {
   ButtonBox,
@@ -13,15 +13,13 @@ import {
   TextBox,
   MailBox,
   ProfileCard,
-  ReturnHeader,
+  TopHeader,
   UserName,
   UserPic,
-  PhoneNumber,
-  StyledNumber,
   StyledText,
   StyledText2,
   StyledText3,
-  EditProfileButton,
+  StyledTextVenmo,
 } from "./ProfileStyles.js";
 import { useState } from "react";
 import LoadingDiv from "../../common/LoadingDiv.js";
@@ -68,21 +66,19 @@ const Profile = () => {
 
   return (
     <div>
-      <ReturnHeader>
+      <TopHeader>
         <ButtonBox onClick={goBack}>
           <BackArrow></BackArrow>
           <StyledText3>Back</StyledText3>
         </ButtonBox>
-      </ReturnHeader>
-      <EditProfileButton>
         <IconButton
           aria-label="edit"
           onClick={() => setOpenDialog(true)}
           variant="outlined"
         >
-          <EditIcon />
+          <EditIcon style={{color:"#2075D8"}} />
         </IconButton>
-      </EditProfileButton>
+      </TopHeader>
       <ProfileDialog
         openDialog={openDialog}
         setOpenDialog={setOpenDialog}
@@ -91,7 +87,7 @@ const Profile = () => {
       <ProfileCard>
         <UserPic></UserPic>
         <UserName>{user.firstName + " " + user.lastName}</UserName>
-        <PhoneNumber  onClick={async () => {
+        <TextBox onClick={async () => {
             if (user.phone) {
               navigator.clipboard.writeText(user.phone).then(
                 addToast("Phone Number Copied to Clipboard!", {
@@ -100,10 +96,9 @@ const Profile = () => {
               );
             }
           }}>
-           <StyledNumber> {user.phone ? user.phone : "Phone Number Unavailable"} &nbsp; </StyledNumber>
-           
-          {user.phone ? <FileCopyIcon fontSize = "small" style={{color: "#2075D8"}}/> : ""}
-        </PhoneNumber>
+            <PhoneIcon/>
+           <StyledText> {user.phone ? user.phone : "Phone Number Unavailable"} </StyledText>
+        </TextBox>
         <TextBox
           onClick={() => {
             navigator.clipboard.writeText(user.netid + "@rice.edu").then(
@@ -113,7 +108,7 @@ const Profile = () => {
             );
           }}
         >
-          <MailBox></MailBox>
+          <MailBox style={{color:"#002140"}}/>
           <StyledText>{user.netid}@rice.edu</StyledText>
         </TextBox>
         <TextBox
@@ -134,9 +129,9 @@ const Profile = () => {
           <StyledText2>
             Venmo
           </StyledText2>
-          <StyledText>
+          <StyledTextVenmo>
             {user.venmo ? `@${user.venmo}` : "Not Specified"}
-          </StyledText>
+          </StyledTextVenmo>
         </TextBox>
       </ProfileCard>
     </div>

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -5,6 +5,8 @@ import { useToasts } from "react-toast-notifications";
 import ProfileDialog from "./ProfileDialog.js";
 import IconButton from "@material-ui/core/IconButton";
 import EditIcon from "@material-ui/icons/Edit";
+import FileCopyIcon from '@material-ui/icons/FileCopy';
+
 import {
   ButtonBox,
   BackArrow,
@@ -15,6 +17,7 @@ import {
   UserName,
   UserPic,
   PhoneNumber,
+  StyledNumber,
   StyledText,
   StyledText2,
   StyledText3,
@@ -88,7 +91,7 @@ const Profile = () => {
       <ProfileCard>
         <UserPic></UserPic>
         <UserName>{user.firstName + " " + user.lastName}</UserName>
-        <PhoneNumber onClick={async () => {
+        <PhoneNumber  onClick={async () => {
             if (user.phone) {
               navigator.clipboard.writeText(user.phone).then(
                 addToast("Phone Number Copied to Clipboard!", {
@@ -97,7 +100,9 @@ const Profile = () => {
               );
             }
           }}>
-          {user.phone ? user.phone : "Phone Number Unavailable"}
+           <StyledNumber> {user.phone ? user.phone : "Phone Number Unavailable"} &nbsp; </StyledNumber>
+           
+          {user.phone ? <FileCopyIcon fontSize = "small" style={{color: "#2075D8"}}/> : ""}
         </PhoneNumber>
         <TextBox
           onClick={() => {

--- a/client/src/Pages/Profile/ProfileStyles.js
+++ b/client/src/Pages/Profile/ProfileStyles.js
@@ -35,6 +35,27 @@ label: {
 }
 })(Button);
 
+const PhoneNumber = withStyles({
+	root:{
+		display: 'flex', 
+		justifyContent: 'center',
+		alignItems: 'center',
+		padding: '.5vh 0 0 0',
+	
+		background: 'white',
+		fontFamily: 'Josefin Sans',
+		fontWeight: '300',
+		fontSize: '18px',
+		textAlign: 'center',
+
+		color: '#002140'
+	},
+	label: {
+		textTransform: 'none',
+	}
+}) (Button);
+
+
 const MailBox = withStyles({
 root: {
 	color: '#2075D8'
@@ -95,19 +116,14 @@ const UserName = styled.p`
 	color: #002140;
 `;
 
-const PhoneNumber = styled.div`
+const StyledNumber = styled.p`
 	display: flex; 
-	justify-content: center;
-	align-items: center;
-	padding: 1vh 0px 0px 0px;
+	padding: 0px 0px 0px 1vh;
 
 	font-family: Josefin Sans;
-	font-weight: 300;
-	font-size: 18px;
-	line-height: 18px;
+	font-weight: '300';
 	text-align: center;
-
-	color: #002140;
+	color: black;
 `;
 
 const StyledText = styled.p`
@@ -168,6 +184,7 @@ export {
 	UserName,
 	UserPic,
 	PhoneNumber,
+	StyledNumber,
 	StyledText,
 	StyledText2,
 	StyledText3

--- a/client/src/Pages/Profile/ProfileStyles.js
+++ b/client/src/Pages/Profile/ProfileStyles.js
@@ -26,7 +26,7 @@ root: {
 	alignItems: 'center',
 	marginTop: '4vh',
 	width: '75vw',
-	height: '10vh',
+	height: '6vh',
 	borderRadius: '9px',
 	background: 'rgba(187, 218, 255, 0.22)'
 }, 
@@ -35,26 +35,6 @@ label: {
 }
 })(Button);
 
-const PhoneNumber = withStyles({
-	root:{
-		display: 'flex', 
-		justifyContent: 'center',
-		alignItems: 'center',
-		padding: '.5vh 0 0 0',
-	
-		background: 'white',
-		fontFamily: 'Josefin Sans',
-		fontWeight: '300',
-		fontSize: '18px',
-		textAlign: 'center',
-
-		color: '#002140'
-	},
-	label: {
-		textTransform: 'none',
-	}
-}) (Button);
-
 
 const MailBox = withStyles({
 root: {
@@ -62,17 +42,6 @@ root: {
 }
 })(MailIcon);
 
-const EditProfileButton = styled.div`
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-direction: column;
-	font-family: Josefin Sans;
-	font-weight: 600;
-	font-size: 30px;
-	line-height: 30px;
-	text-align: center;
-`
 
 const ProfileCard = styled.div`
 	display: flex;
@@ -81,11 +50,12 @@ const ProfileCard = styled.div`
 	flex-direction: column;
 `;
 
-const ReturnHeader = styled.div`
+const TopHeader = styled.div`
 	display: flex;
-	justify-content: flex-start;
+	justify-content: space-between;
+	margin-right: 25px;
 	align-items: center;
-	padding: 0 10px 10px 0;
+	padding: 15px;
 `;
 
 const UserPic = styled.img`
@@ -109,21 +79,10 @@ const UserName = styled.p`
 
 	font-family: Josefin Sans;
 	font-weight: 600;
-	font-size: 30px;
-	line-height: 30px;
+	font-size: 2.2em;
 	text-align: center;
 
 	color: #002140;
-`;
-
-const StyledNumber = styled.p`
-	display: flex; 
-	padding: 0px 0px 0px 1vh;
-
-	font-family: Josefin Sans;
-	font-weight: '300';
-	text-align: center;
-	color: black;
 `;
 
 const StyledText = styled.p`
@@ -133,10 +92,9 @@ const StyledText = styled.p`
 	font-family: Josefin Sans;
 	font-style: normal;
 	font-weight: normal;
-	font-size: 18px;
-	line-height: 18px;
+	font-size: 1.5em;
 	text-align: center;
-	color: #2075D8;
+	color: #002140;
 `;
 
 const StyledText2 = styled.p`
@@ -150,10 +108,9 @@ const StyledText2 = styled.p`
 	font-weight: 600;
 	font-size: 13px;
 	line-height: 13px;
-	text-align: center;
-	letter-spacing: 0.07em;
+	text-align: center;	
 
-	color: #2075D8;
+	color: #002140;
 `;
 
 const StyledText3 = styled.p`
@@ -173,19 +130,29 @@ const StyledText3 = styled.p`
 	color: #2075D8;
 `;
 
+const StyledTextVenmo = styled.p`
+	display: flex; 
+	padding: 0px 0px 0px 1vh;
+
+	font-family: Josefin Sans;
+	font-style: normal;
+	font-weight: normal;
+	font-size: 1.5em;
+	text-align: center;
+	color: rgba(32, 117, 216, 1);
+`;
+
 export {
 	ButtonBox,
 	BackArrow,
 	TextBox,
 	MailBox,
-	EditProfileButton,
 	ProfileCard,
-	ReturnHeader,
+	TopHeader,
 	UserName,
 	UserPic,
-	PhoneNumber,
-	StyledNumber,
 	StyledText,
 	StyledText2,
-	StyledText3
+	StyledText3,
+	StyledTextVenmo
 };

--- a/client/src/Pages/Profile/ProfileStyles.js
+++ b/client/src/Pages/Profile/ProfileStyles.js
@@ -95,11 +95,11 @@ const UserName = styled.p`
 	color: #002140;
 `;
 
-const PhoneNumber = styled.p`
+const PhoneNumber = styled.div`
 	display: flex; 
 	justify-content: center;
 	align-items: center;
-	padding: 1vh 0px 25px 0px;
+	padding: 1vh 0px 0px 0px;
 
 	font-family: Josefin Sans;
 	font-weight: 300;


### PR DESCRIPTION
# Description

Made the phone number text into a copyable button like the email text and venmo field.
Also updated the user profile page to be up to date with the current design spec.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New Design:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/65870703/155672236-0c035e7c-dec7-4ccf-97fb-7ef6bda3d61f.png">
<img width="352" alt="image" src="https://user-images.githubusercontent.com/65870703/155672725-8984f54c-27d6-483c-afcc-69a7e2873bd3.png">


Notes: 
Pressing the phone number button when the phone number is unavailable does nothing.
Also note, having a really long venmo name may have the text go beyond the boundary of the container; will update
