### PR TITLE
Remove Navbar from Onboarding and UserAuth Pages

### DIFF
--- a/client/src/Pages/Onboarding/OnboardingFormStyle.js
+++ b/client/src/Pages/Onboarding/OnboardingFormStyle.js
@@ -20,6 +20,7 @@ export const Header = styled.div`
   font-size: 2.5vh;
   line-height: 2vh;
   color: #2075d8; 
+  padding-bottom: 3vh;
 `;
 
 export const Label = styled(InputLabel)({
@@ -44,6 +45,7 @@ export const ProfileFormContainer = styled.div`
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
+  padding-top: 8vh;
 `;
 
 export const ProfileStyles = makeStyles(() => ({

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -75,7 +75,6 @@ export default function ButtonAppBar (props) {
   const [drawer, setDrawer] = useState(false);
   const loggedIn = localStorage.getItem('token') != null;
   const [showBar, setShowBar] = useState(false);
-  const nonNavBarUrl = ["/", "/home", "/userAuth", "/onboarding"]
 
   const toggleDrawer = () => setDrawer(!drawer);
 
@@ -89,10 +88,10 @@ export default function ButtonAppBar (props) {
   );
   const location = useLocation();
   useEffect(() => {
-    if (nonNavBarUrl.includes(location.pathname)){
+    if (["/", "/home", "/userAuth", "/onboarding"].includes(location.pathname)){
       setShowBar(false)
     }
-    else{ 
+    else { 
       setShowBar(true)
     }
   }, [location.pathname])

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -75,6 +75,7 @@ export default function ButtonAppBar (props) {
   const [drawer, setDrawer] = useState(false);
   const loggedIn = localStorage.getItem('token') != null;
   const [showBar, setShowBar] = useState(false);
+  const nonNavBarUrl = ["/", "/home", "/userAuth", "/onboarding"]
 
   const toggleDrawer = () => setDrawer(!drawer);
 
@@ -88,7 +89,7 @@ export default function ButtonAppBar (props) {
   );
   const location = useLocation();
   useEffect(() => {
-    if (location.pathname === "/home" || location.pathname === "/"){
+    if (nonNavBarUrl.includes(location.pathname)){
       setShowBar(false)
     }
     else{ 


### PR DESCRIPTION
# Description

Having the navigation bar available on the onboarding page allows the user to (a) see the "null null" and (b) navigate away while their onboarding process is incomplete. This change removes the navbar from the pages and updates the CSS of the onboarding to adjust for the change. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

A new user who arrives at the Onboarding page should not be able to see the navigation bar. Also, I also checked the overall flow of the onboarding process with this change and everything appeared less sketchy since we wouldn't be able to see the "null null" anymore during onboarding :D

<img width="291" alt="Screen Shot 2022-02-25 at 1 42 55 AM" src="https://user-images.githubusercontent.com/53880607/155675420-7fcef7eb-5171-4646-9b0c-b5b20db97c29.png">


