### PR TITLE
Term Message for RIde Creation and Join Ride

### DIFF
--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -16,12 +16,11 @@ import {
     MenuBox,
     ColorButton,
     InputBox,
-    FormControlLabelBox,
     DateBox,
-    CheckBox,
     SelectSquare,
     MenuSquare,
-    BodyText
+    BodyText, 
+    ConfirmationText
 } from './Create.styles'
 import LoadingDiv from '../../common/LoadingDiv.js';
 
@@ -55,7 +54,7 @@ const Create = ({onCreate}) => {
     const [endLoc, setEndLoc] = useState('')
     const [date, setDate] = useState(new Date())
     const [passengers, setPassengers] = useState(3)
-    const [confirmation, setConfirmation] = useState(false)
+    const confirmationText = "You will still need to contact your fellow riders and order an Uber or Lyft on the day of."
 
     // Function after Submit Button is Pressed
     const onSubmit = (e) => {
@@ -73,20 +72,14 @@ const Create = ({onCreate}) => {
             return;
         }
 
-        if (!confirmation) {
-            addToast("You must agree to lead the ride to create this ride.", { appearance: 'error' });
-            return
-        }
-
         // Pass arguments back to the top mutation queue
-        onCreate({ startLoc, endLoc, date, passengers, notes, confirmation, users, owner})
+        onCreate({ startLoc, endLoc, date, passengers, notes, users, owner })
 
         setStartLoc('')
         setEndLoc('')
         setNotes('')
         setDate(new Date())
         setPassengers(4)
-        setConfirmation(false)
     }
 
     // OnChange Functions: Triggers for User Changing Fields
@@ -104,10 +97,6 @@ const Create = ({onCreate}) => {
     const onEndLocChange = (e) => {
         e.preventDefault()
         setEndLoc(e.target.value);
-    };
-
-    const onCheck = (e) => {
-        setConfirmation(e.target.checked);
     };
 
     const onPassengerChange = (e) => {
@@ -322,12 +311,9 @@ const Create = ({onCreate}) => {
 
                 <Grid
                     item
-                    xs = {12}
+                    xs = {11}
                 >
-                    <FormControlLabelBox
-                        control={<CheckBox color='primary' checked={confirmation} onChange={onCheck}/>}
-                        label="I am responsible for coordinating this ride."
-                    />
+                    <ConfirmationText>{confirmationText}</ConfirmationText>
                 </Grid>
 
                 <Grid 

--- a/client/src/Pages/CreateRide/Create.styles.js
+++ b/client/src/Pages/CreateRide/Create.styles.js
@@ -7,8 +7,6 @@ import {
     Select, 
     TextField,
     InputLabel,
-    FormControlLabel, 
-    Checkbox, 
     createTheme
 } from '@material-ui/core';
 
@@ -114,29 +112,11 @@ export const ColorButton = withStyles({
     }
   })(TextField);
 
-
-  export const FormControlLabelBox = withStyles({
-    label: {
-        display: 'flex',
-        alignItems: 'center',
-        color: '#0B3669',
-        fontFamily: 'Josefin Sans',
-        fontSize: '13px',
-    }
-  })(FormControlLabel);
-
   export const DateBox = withStyles({
     root: {
 
     }, 
   })(DateTimePicker);
-
-  export const CheckBox = withStyles({
-      root: {
-        color: '#0B3669', 
-        backgroundColor: 'transparent'
-      }
-  })(Checkbox);
 
   export const SelectSquare = withStyles({
     root: {
@@ -184,3 +164,16 @@ export const ColorButton = withStyles({
     color: #0B3669;
     padding: 10px 0px 0px 0px;
   `;
+
+  export const ConfirmationText = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: Josefin Sans;
+  font-style: italic;
+  font-weight: lighter;
+  font-size: 1.50vh;
+  line-height: 2vh;
+  color: #0B3669;
+  padding: 10px 0px 0px 0px;
+`;

--- a/client/src/Pages/Onboarding/Alert.styles.js
+++ b/client/src/Pages/Onboarding/Alert.styles.js
@@ -14,14 +14,14 @@ export const LoginButton = withStyles({
         display: 'absolute',
         justifyContent: 'center',
         background: '#2075D8',
-        width: '50vw',
+        width: '55vw',
         borderRadius: 25,
         color: 'white',
         height: '5vh',
     },
     label: {
       textTransform: 'capitalize',
-      fontFamily: 'Josefin Sans'
+      fontFamily: 'Josefin Sans',
     },
 })(Button);
 
@@ -31,8 +31,6 @@ export const LoginDialog = withStyles({
         border: 0, 
     }, 
     paper: {
-        display: 'flex',
-        justifyContent: 'align-start',
         background: '#FFFFFF',
         width: '75vw',
         height: '20vh',
@@ -40,9 +38,23 @@ export const LoginDialog = withStyles({
     }
 })(Dialog); 
 
+export const JoinRideDialog = withStyles({
+    root: {
+        borderRadius: 8, 
+        border: 0, 
+    }, 
+    paper: {
+        background: '#FFFFFF',
+        width: '75vw',
+        height: '25vh',
+        padding: '0px'
+    }
+})(Dialog); 
+
 export const LoginDialogActions = withStyles({
     root: {
-        justifyContent: 'center',
+        justifyContent: 'space-between',
+        flexDirection: 'column',
         padding: '2vh 1vw'
     }
 })(DialogActions); 

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -39,10 +39,11 @@ import {
   InnerLocationDiv,
   DepartureIconDiv,
   CalendarText,
-  TimeText
+  TimeText, 
+  ConfirmationText
 } from './RideSummaryStyles.js'
 import { Grid, IconButton } from '@material-ui/core';
-import { LoginButton, LoginDialog, LoginDialogActions} from '../Onboarding/Alert.styles.js';
+import { LoginButton, JoinRideDialog, LoginDialogActions} from '../Onboarding/Alert.styles.js';
 import CloseIcon from '@material-ui/icons/Close';
 // SSO imports
 import { SERVICE_URL } from '../../config'; 
@@ -50,6 +51,7 @@ import LoadingDiv from '../../common/LoadingDiv.js'
 import { useToasts } from "react-toast-notifications";
 
 const casLoginURL = 'https://idp.rice.edu/idp/profile/cas/login'; 
+const confirmationText = "You will still need to contact your fellow riders and order an Uber or Lyft on the day of."
 
 const GET_RIDE = gql`
   query getRide($id: MongoID) {
@@ -91,7 +93,8 @@ const RideSummary = () => {
   const history = useHistory()
   const { addToast } = useToasts();
   // States to control for Dialog
-  const [openAlert, setOpenAlert] = useState(false);
+  const [openLogin, setOpenLogin] = useState(false);
+  const [openConfirmation, setOpenConfirmation] = useState(false);
 
   const { data, loading, error } = useQuery(GET_RIDE, {
     variables: {id: id},
@@ -134,19 +137,23 @@ const RideSummary = () => {
   const handleClickOpen = () => {
     // User is logged in already via Rice Verification
     if (localStorage.getItem('token') != null) {
-        // Verify if user is in Carpool Database by triggering the Query
-        join();
+      // Show the confirmation pop-up for joining ride
+      setOpenConfirmation(true); 
     } 
     // User is not logged in, prompt them to log in
     else {
-        setOpenAlert(true);
+      setOpenLogin(true);
     }
-    
   };
 
-  // Close the dialog box
-  const handleClose = () => {
-      setOpenAlert(false);
+  // Close the  box
+  const handleCloseLogin= () => {
+      setOpenLogin(false);
+  };
+
+  // Close the confirmation panel
+  const handleCloseConfirmation = () => {
+      setOpenConfirmation(false);
   };
 
   useEffect(() => {
@@ -327,24 +334,44 @@ const RideSummary = () => {
           Join Ride
         </ButtonDiv>}
       </ButtonContainer>
-      <LoginDialog
-                open={openAlert}
-                onClose={handleClose}
+      <JoinRideDialog
+                open={openLogin}
+                onClose={handleCloseLogin}
             >
-            <Grid container spacing = {12}>
+            <Grid container spacing = {12} justifyContent = "center">
                 <Grid item sm = {11} xs = {10}/>
                 <Grid item sm = {1} xs = {2}>
-                    <IconButton onClick = {handleClose} size = "medium">
+                    <IconButton onClick = {handleCloseLogin} size = "medium">
                         <CloseIcon />
                     </IconButton>
                 </Grid>
-                <Grid item xs = {12}>
+                <Grid item xs = {10} justifyContent = "center">
+                    <ConfirmationText>{confirmationText}</ConfirmationText>
                     <LoginDialogActions>
-                        <LoginButton onClick={join} autoFocus>Rice SSO Login</LoginButton>
+                        <LoginButton onClick={join} autoFocus>Got it! Login with Rice SSO</LoginButton>
                     </LoginDialogActions>
                   </Grid>
             </Grid>
-      </LoginDialog>
+      </JoinRideDialog>
+      <JoinRideDialog
+                open={openConfirmation}
+                onClose={handleCloseConfirmation}
+            >
+            <Grid container spacing = {12} justifyContent = "center">
+                <Grid item sm = {11} xs = {10}/>
+                <Grid item sm = {1} xs = {2}>
+                    <IconButton onClick = {handleCloseConfirmation} size = "medium">
+                        <CloseIcon />
+                    </IconButton>
+                </Grid>
+                <Grid item xs = {10} justifyContent = "center">
+                  <ConfirmationText>{confirmationText}</ConfirmationText>
+                    <LoginDialogActions>
+                        <LoginButton onClick={join} autoFocus>Got it! Join Ride</LoginButton>
+                    </LoginDialogActions>
+                  </Grid>
+            </Grid>
+      </JoinRideDialog>
     </AllDiv>
   )
 }

--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -324,6 +324,18 @@ const InnerLocationDiv = styled.div`
 padding: 20px;
 `
 
+const ConfirmationText = styled.div`
+display: flex;
+justify-content: center;
+align-items: center;
+font-family: Josefin Sans;
+font-style: italic;
+font-weight: lighter;
+font-size: 1.5vh;
+line-height: 2vh;
+color: #0B3669;
+padding: 0px 10px 10px 10px;
+`;
 
 export {
   SeatsLeftDiv,
@@ -359,5 +371,6 @@ export {
   InnerLocationDiv,
   DepartureIconDiv,
   CalendarText,
-  TimeText
+  TimeText, 
+  ConfirmationText
 }


### PR DESCRIPTION
# Description

Updated the alert message for CreateRide and JoinRide. 
CreateRide: Removed the checkbox and added italicized text above the create ride button for confirmation. 
JoinRIde: Implemented two versions of a pop-up with the ride confirmation text for users that are logged in vs. not logged in

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Attempted to join the ride as both a non-user and user, the pop-ups show up correctly and the ride join + onboarding flow is as expected. The SSO login pop-up in CreateRide is the same dimension as before. 

CreateRide
<img width="290" alt="Screen Shot 2022-02-25 at 11 42 54 PM" src="https://user-images.githubusercontent.com/53880607/155830920-145669a0-ee84-4c4e-9d2e-ee45229f1e65.png">

Join Ride as Logged-In User
<img width="292" alt="Screen Shot 2022-02-25 at 11 32 39 PM" src="https://user-images.githubusercontent.com/53880607/155830898-34851d87-c4aa-40f2-9962-bd4f4afcd627.png">

Join Ride as New/Logged-Out User
<img width="289" alt="Screen Shot 2022-02-25 at 11 32 14 PM" src="https://user-images.githubusercontent.com/53880607/155830899-d2fc6e0b-2ac5-402b-980a-db3dc5cf91e0.png">


