### PR TITLE
Make Your Rides page GraphQL query faster

### DIFF
--- a/api/schema/RideSchema.js
+++ b/api/schema/RideSchema.js
@@ -46,11 +46,11 @@ RideTC.addRelation('arrivalLocation', {
 RideTC.addResolver({
   name: 'findByUser',
   type: [RideTC],
-  args: { _id: 'ID!' },
   resolve: async ({ source, args, context, info }) => {
+    const { id } = context.decodedJWT
     // Return all rides where the user is an owner or a rider
     return await Ride.find({
-      $or: [{ owner: args._id }, { riders: { $in: [args._id] } }],
+      $or: [{ owner: id }, { riders: { $in: [id] } }],
     })
   },
 })
@@ -94,6 +94,7 @@ RideTC.addResolver({
 const RideQuery = {
   rideOne: RideTC.getResolver('findOne'),
   rideMany: RideTC.getResolver('findMany'),
+  rideByUser: RideTC.getResolver('findByUser'),
 }
 
 // TODO: Add [authMiddleware] back to all getResolver calls once login is implemented!

--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -18,7 +18,7 @@ import LoadingDiv from '../../common/LoadingDiv.js';
 
 const GET_RIDES = gql`
 	query {
-		rideMany {
+		rideByUser {
 			_id
 			departureDate
 			riders {
@@ -44,27 +44,17 @@ const GET_RIDES = gql`
 	}
 `;
 
-
 const YourRides = (paid) => {
-
     let netid = localStorage.getItem("netid")
 
-		// const [allRides, setAllRides] = useEffect([])
-		const [prevRides, setPrevRides] = useState([])
-		const [futureRides, setFutureRides] = useState([])
+    // const [allRides, setAllRides] = useEffect([])
+    const [prevRides, setPrevRides] = useState([])
+    const [futureRides, setFutureRides] = useState([])
     const { data, loading, error } = useQuery(GET_RIDES);
 
     useEffect(() => {
         if (data) {
-            let rides = data.rideMany.filter(ride => {
-                let ownerTrue = false
-                let riderTrue = false
-                if (ride.owner) {
-                    ownerTrue = ride.owner.netid === netid
-                }
-                ride.riders.forEach(rider => riderTrue = (riderTrue === true || rider.netid === netid))
-                return ownerTrue || riderTrue
-            })
+            let rides = data.rideByUser
 
             let previousrides = rides.filter(ride => moment(ride.departureDate) < new Date())
             previousrides.sort((a, b) => moment(b.departureDate) - moment(a.departureDate))
@@ -101,10 +91,7 @@ const YourRides = (paid) => {
                 </UpcomingRidesSection>
 
                 <PastRidesSection>
-                    <PastRideTitle>
-                        <TitleText>Past Rides</TitleText>
-                        {/* <TitleText>Payments</TitleText> */}
-                    </PastRideTitle>
+                    <PastRideTitle><TitleText>Past Rides</TitleText><TitleText>Payments</TitleText></PastRideTitle>
                     {prevRides.map(ride => {
                         return (
                             <PastRideCard 


### PR DESCRIPTION
# Description

Fetch just the rides we need, GraphQL-style.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Make sure both rides you own and rides you are a non-owning part of show up
- Make sure the rides are sorted reverse-chronologically
- Make sure the rides are correctly split into "Upcoming" and "Past"