### PR TITLE
Added box shadow to each rider in ride summary

### DIFF
--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -193,6 +193,7 @@ const OneRiderContainer = styled.div`
   margin: 15px;
   width: 97%;
   font-family: Josefin Sans;
+  box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.25);
 `
 const RiderText = styled.div`
   padding-top: 17px;
@@ -215,7 +216,7 @@ const TextContainer = styled.div`
 `
 const ButtonDiv = styled.button`
   color: #ffffff;
-  background: ${({ disabled, leaveRide }) => leaveRide ? 'red' : !disabled ? '#2075d8' : '#9e9e9e'};
+  background: ${({ disabled, leaveRide }) => leaveRide ? 'rgba(235, 82, 72, 1)' : !disabled ? '#2075d8' : '#9e9e9e'};
   text-align: center;
   font-family: Josefin Sans;
   font-style: normal;


### PR DESCRIPTION

# Description

Made each rider look clickable by adding a shadow. Also changed color of leave ride button to match design

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="388" alt="image" src="https://user-images.githubusercontent.com/65870703/155855747-4ddf7ddf-100a-4cd9-bd7b-def3a3f4a022.png">

