### PR TITLE
Sorting in Your Rides

### DIFF
--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -62,7 +62,7 @@ const YourRides = (paid) => {
             let previousrides = rides.filter(ride => moment(ride.departureDate) < new Date())
             previousrides.sort((a, b) => moment(b.departureDate) - moment(a.departureDate))
             let upcomingrides = rides.filter(ride => moment(ride.departureDate) >= new Date())
-            upcomingrides.sort((a, b) => moment(b.departureDate) - moment(a.departureDate))
+            upcomingrides.sort((a, b) => moment(a.departureDate) - moment(b.departureDate))
 
             console.log("previousRides", previousrides)
             console.log("upcomingRides", upcomingrides)


### PR DESCRIPTION
# Description

FIx the sorting in Your Rides such that: 
- Upcoming Rides: earliest to latest
- Past Rides: latest to earliest

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on past rides and future rides at varying times. 
<img width="196" alt="Screen Shot 2022-02-26 at 1 31 34 PM" src="https://user-images.githubusercontent.com/53880607/155856739-c8f26e05-3edf-4acb-91e2-116ea466b29a.png">

