### PR TITLE
full rides now show up under matching rides

### DIFF
--- a/client/src/Pages/Search/DisplayRides.js
+++ b/client/src/Pages/Search/DisplayRides.js
@@ -131,10 +131,11 @@ const DisplayRides = (props) => {
                     <p> Don't see a match? </p> &nbsp; Create a new ride 
             </StyledButton>
             {
-                <div style = {{paddingTop: '1vh', fontSize: "4vh", fontFamily: "Josefin Sans"}}>All Rides:</div>
+                <div style = {{paddingTop: '1vh', fontSize: "4vh", fontFamily: "Josefin Sans"}}>All Open Rides:</div>
             }
             {
-                props.ridesPossible.filter((ride) => { return !ridesT.some(e => isEqualRides(ride, e))}).map((ride, ind) => (<Ride ride={ride} />))
+                props.ridesPossible.filter((ride) => { 
+                    return !ridesT.some(e => isEqualRides(ride, e))}).filter(ride => (ride.spots - ride.riders.length > 0)).map((ride, ind) => (<Ride ride={ride} />))
             }
             <Grid item justify="center" align='center' style={{ display: 'flex', alignItems: 'center', fontFamily: "Josefin Sans", fontSize: "2vh", color: "#012E62"}}>
                 no more results

--- a/client/src/Pages/Search/FormOnly.js
+++ b/client/src/Pages/Search/FormOnly.js
@@ -38,8 +38,7 @@ const FormOnly = (props) => {
             currentDate,
             true
           );
-          const isNotFull = ride.spots - ride.riders.length > 0;
-          return rideDateAfterCurrentDate && isNotFull;
+          return rideDateAfterCurrentDate;
         });
 
         setRidesPossibleForm(ridesPossibleNotBefore);


### PR DESCRIPTION
# Description

Full rides (0 seats left) now show up under matching rides;

## Type of change


- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/65870703/155857111-3aa95393-b554-4a5c-9848-5a19ba3b917e.png">
<img width="1351" alt="image" src="https://user-images.githubusercontent.com/65870703/155857193-359dea83-9062-4b5d-a6f0-5c8b8902f9be.png">

