### PR TITLE
fixed scrolling pages; updated navbar colors on ride summary and profile page

### DIFF
--- a/client/src/Pages/Profile/ProfileStyles.js
+++ b/client/src/Pages/Profile/ProfileStyles.js
@@ -45,7 +45,7 @@ export const MailBox = withStyles({
 
 export const AllDiv = styled.div`
   background: #f4f6f9;
-  height: 100vh;
+  height: calc(100vh - 64px);
 `
 
 export const EditProfileButton = styled.div`

--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -243,7 +243,7 @@ const ButtonDiv = styled.button`
 `
 const AllDiv = styled.div`
   background: #f4f6f9;
-  height: 100vh;
+  height: calc(100vh - 64px);
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: min-content;

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -30,7 +30,8 @@ export default function ButtonAppBar (props) {
 
     // set appbar colour
   const currURL = window.location.pathname;
-  const [appbarColor, setAppbarColor] = useState((currURL === "/about" || currURL === "/FAQ") ? "#012E62" : "white")
+  const [appbarColor, setAppbarColor] = useState((currURL === "/about" || currURL === "/FAQ") ? "#012E62" : 
+  ((currURL.includes("/ridesummary") || currURL.includes("/profile")) ? "rgb(244, 246, 249)" : "white"))
 
   const [hamburgerColor, setHamburgerColor] = useState((currURL === "/about" || currURL === "/FAQ") ? "white" : "#002140")
 
@@ -132,7 +133,8 @@ export default function ButtonAppBar (props) {
       setShowBar(true)
     }
 
-    setAppbarColor((currURL === "/about" || currURL === "/FAQ") ? "#012E62" : "white")
+    setAppbarColor((currURL === "/about" || currURL === "/FAQ") ? "#012E62" : 
+    ((currURL.includes("/ridesummary") || currURL.includes("/profile")) ? "rgb(244, 246, 249)" : "white"))
 
     setHamburgerColor((currURL === "/about" || currURL === "/FAQ") ? "white" : "#002140")
 
@@ -234,7 +236,7 @@ export default function ButtonAppBar (props) {
           color= "black" 
           elevation="0" 
           className={classes.appbarRoot}> 
-          <Toolbar>
+          <Toolbar style ={{height: "64px"}}>
             <IconButton edge="start" className={classes.burgerIcon} onClick = {toggleDrawer} aria-label="menu">
               <MenuIcon fontSize="large"/>
             </IconButton>
@@ -243,7 +245,7 @@ export default function ButtonAppBar (props) {
             </Drawer>
           </Toolbar>
         </AppBar>
-        <Toolbar/>
+        <Toolbar style ={{height: "64px"}}/>
     </div>
     : null
   }


### PR DESCRIPTION
# Description
Fixed scrollable pages by: fixing the height of the toolbar/navbar.
Allows us to calculate exactly the size of the rest of the screen: 100vh - 64px

Updated navbar color on ridesummary and profile page to match the background


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<img width="500" alt="image" src="https://user-images.githubusercontent.com/65870703/155957166-31c5337c-6881-4df5-b957-0227fce69ef3.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/65870703/155957441-cc594f12-056a-4f0b-98a1-7d3f25c273be.png">
