### PR TITLE
Remove pencil icon from edit profile page

### DIFF
--- a/client/src/Pages/Profile/ProfileDialog.js
+++ b/client/src/Pages/Profile/ProfileDialog.js
@@ -6,7 +6,7 @@ import {
   IconBox,
   ButtonBox,
   ProfileIcon,
-  ProfileEditIcon,
+//  ProfileEditIcon,
   CloseProfileIcon,
   Label,
   VenmoTextField,
@@ -114,7 +114,7 @@ export default function ProfileDialog(props) {
             <ProfileDialogContainer>
               <IconBox>
                 <ProfileIcon />
-                <ProfileEditIcon />
+                {/* <ProfileEditIcon /> */}
                 <CloseProfileIcon onClick={closeDialog} />
               </IconBox>
 


### PR DESCRIPTION
# Description

Simply commented out the pencil icon from the edit profile page because it is unclickable. To be restored later when profile pics are implemented.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please include:
- Try to edit your profile and see that the pencil icon is no longer there (still exists on the regular profile page)
