### PR TITLE
Make Profile Private Access

### DIFF
--- a/client/src/Pages/Auth/UserAuth.js
+++ b/client/src/Pages/Auth/UserAuth.js
@@ -45,7 +45,7 @@ const UserAuth = () => {
   } 
 
   // If the user returned to UserAuth from profile page, let them go further back
-  if (previous === "profile"){
+  if (previous.includes("profile")){
     history.goBack();
   }
 

--- a/client/src/Pages/Auth/UserAuth.js
+++ b/client/src/Pages/Auth/UserAuth.js
@@ -37,12 +37,17 @@ const UserAuth = () => {
     }
   );
   
-  // Check to see if the user came here via going back
+  // Check to see if the user came here via going back from onboarding
   if (previous === 'onboarding'){
     localStorage.clear();
     // Go back further
     history.goBack();
   } 
+
+  // If the user returned to UserAuth from profile page, let them go further back
+  if (previous === "profile"){
+    history.goBack();
+  }
 
   // Determining where to route to
   useEffect(() => {

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -43,10 +43,15 @@ const Onboarding = () => {
 
   const [updateUser] = useMutation(UPDATE_USER);
 
+  // Edge Case: Pressing Back Button from Onboarding into Profile Form
+  if (previous.includes("profile") && (localStorage.getItem("fromOnboarding") === true)){
+    history.goBack();
+  }
+
   const updateUserInfo = async (formData) => {
  
     await updateUser({ variables: formData });
-
+    localStorage.setItem("fromOnboarding", true);
     const nextPage = localStorage.getItem("nextPage");
     if (nextPage) {
       localStorage.removeItem("nextPage");
@@ -84,19 +89,23 @@ const Onboarding = () => {
   };
 
   useEffect(() => {
-    addToast(
-      'If you would not like to onboard, please use the "Cancel" button below.',
-      {
-        appearance: "warning",
-        autoDismiss: true,
-        autoDismissTimeout: 12000,
+      addToast(
+        'If you would not like to onboard, please use the "Cancel" button below.',
+        {
+          appearance: "warning",
+          autoDismiss: true,
+          autoDismissTimeout: 12000,
+        }
+      );
+      if (!(previous.includes("profile"))){
+        console.log("EVENT LISTENER");
+        window.history.pushState(null, null, window.location.pathname);
+        window.addEventListener("popstate", onBackButtonEvent);
+        return () => {
+          window.removeEventListener("popstate", onBackButtonEvent);
+        };
       }
-    );
-    window.history.pushState(null, null, window.location.pathname);
-    window.addEventListener("popstate", onBackButtonEvent);
-    return () => {
-      window.removeEventListener("popstate", onBackButtonEvent);
-    };
+      
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -45,9 +45,9 @@ const Onboarding = () => {
 
   // Edge Case: Pressing Back Button from Onboarding into Profile Form
   if (previous.includes("profile") && (localStorage.getItem("skipOnboarding") === "true")){
-    // localStorage.removeItem("fromOnboardng");
     console.log("Attempt to go back to UserAuth");
-    history.goBack();
+    localStorage.removeItem("skipOnboarding");
+    history.go(-1);
   }
 
   const updateUserInfo = async (formData) => {

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -44,14 +44,16 @@ const Onboarding = () => {
   const [updateUser] = useMutation(UPDATE_USER);
 
   // Edge Case: Pressing Back Button from Onboarding into Profile Form
-  if (previous.includes("profile") && (localStorage.getItem("fromOnboarding") === true)){
+  if (previous.includes("profile") && (localStorage.getItem("skipOnboarding") === "true")){
+    // localStorage.removeItem("fromOnboardng");
+    console.log("Attempt to go back to UserAuth");
     history.goBack();
   }
 
   const updateUserInfo = async (formData) => {
  
     await updateUser({ variables: formData });
-    localStorage.setItem("fromOnboarding", true);
+    // localStorage.setItem("fromOnboarding", true);
     const nextPage = localStorage.getItem("nextPage");
     if (nextPage) {
       localStorage.removeItem("nextPage");

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -59,7 +59,8 @@ const Onboarding = () => {
 
   const cancelOnboarding = () => {
     localStorage.clear();
-    if (previous) {
+    console.log("previous", previous)
+    if (previous && previous !== "onboarding") {
       window.open(previous, "_self");
     }
     // default behavior is to route to home page

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -59,7 +59,6 @@ const Onboarding = () => {
 
   const cancelOnboarding = () => {
     localStorage.clear();
-    console.log("previous", previous)
     if (previous && previous !== "onboarding") {
       window.open(previous, "_self");
     }
@@ -88,7 +87,6 @@ const Onboarding = () => {
       localStorage.setItem("lastPage", "onboarding");
       // Edge Case: Pressing Back Button from Onboarding into Profile Form
       if (previous.includes("profile") && (localStorage.getItem("skipOnboarding") === "true")){
-        console.log("Attempt to go back to UserAuth");
         localStorage.removeItem("skipOnboarding");
         history.push(localStorage.getItem("lastRide"));
       } else {
@@ -102,7 +100,6 @@ const Onboarding = () => {
         );
       }
       if (!(previous.includes("profile"))){
-        console.log("EVENT LISTENER");
         window.history.pushState(null, null, window.location.pathname);
         window.addEventListener("popstate", onBackButtonEvent);
         return () => {

--- a/client/src/Pages/Onboarding/Onboarding.js
+++ b/client/src/Pages/Onboarding/Onboarding.js
@@ -43,13 +43,6 @@ const Onboarding = () => {
 
   const [updateUser] = useMutation(UPDATE_USER);
 
-  // Edge Case: Pressing Back Button from Onboarding into Profile Form
-  if (previous.includes("profile") && (localStorage.getItem("skipOnboarding") === "true")){
-    console.log("Attempt to go back to UserAuth");
-    localStorage.removeItem("skipOnboarding");
-    history.go(-1);
-  }
-
   const updateUserInfo = async (formData) => {
  
     await updateUser({ variables: formData });
@@ -91,14 +84,22 @@ const Onboarding = () => {
   };
 
   useEffect(() => {
-      addToast(
-        'If you would not like to onboard, please use the "Cancel" button below.',
-        {
-          appearance: "warning",
-          autoDismiss: true,
-          autoDismissTimeout: 12000,
-        }
-      );
+      localStorage.setItem("lastPage", "onboarding");
+      // Edge Case: Pressing Back Button from Onboarding into Profile Form
+      if (previous.includes("profile") && (localStorage.getItem("skipOnboarding") === "true")){
+        console.log("Attempt to go back to UserAuth");
+        localStorage.removeItem("skipOnboarding");
+        history.push(localStorage.getItem("lastRide"));
+      } else {
+        addToast(
+          'If you would not like to onboard, please use the "Cancel" button below.',
+          {
+            appearance: "warning",
+            autoDismiss: true,
+            autoDismissTimeout: 12000,
+          }
+        );
+      }
       if (!(previous.includes("profile"))){
         console.log("EVENT LISTENER");
         window.history.pushState(null, null, window.location.pathname);

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams } from "react-router";
+import { useParams, useHistory } from "react-router";
 import { gql, useQuery } from "@apollo/client";
 import { useToasts } from "react-toast-notifications";
 import ProfileDialog from "./ProfileDialog.js";
@@ -34,6 +34,7 @@ const Profile = () => {
   const { id } = useParams();
 
   const { addToast } = useToasts();
+  const history = useHistory();
 
   const GET_USER = gql`
     query GetUserInfo($netID: String) {
@@ -63,8 +64,17 @@ const Profile = () => {
   if (!user) return <div>Invalid User ID</div>;
 
   function goBack() {
+    if (localStorage.getItem("lastPage") === "onboarding"){
+      localStorage.setItem("skipOnboarding", "true");
+    }
     localStorage.setItem('lastPage', 'profile/' + user.netid);
-    window.history.back();
+    if (localStorage.getItem("skipOnboarding") === "true"){ 
+      history.go(-4);
+      localStorage.removeItem("skipOnboarding");
+    } else {
+      history.goBack();
+    }
+
   }
 
   return (

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -68,13 +68,7 @@ const Profile = () => {
       localStorage.setItem("skipOnboarding", "true");
     }
     localStorage.setItem('lastPage', 'profile/' + user.netid);
-    if (localStorage.getItem("skipOnboarding") === "true"){ 
-      history.go(-4);
-      localStorage.removeItem("skipOnboarding");
-    } else {
-      history.goBack();
-    }
-
+    window.history.back();
   }
 
   return (

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -63,7 +63,7 @@ const Profile = () => {
   if (!user) return <div>Invalid User ID</div>;
 
   function goBack() {
-    localStorage.setItem('lastPage', 'profile');
+    localStorage.setItem('lastPage', 'profile/' + user.netid);
     window.history.back();
   }
 

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams, useHistory } from "react-router";
+import { useParams } from "react-router";
 import { gql, useQuery } from "@apollo/client";
 import { useToasts } from "react-toast-notifications";
 import ProfileDialog from "./ProfileDialog.js";
@@ -34,7 +34,6 @@ const Profile = () => {
   const { id } = useParams();
 
   const { addToast } = useToasts();
-  const history = useHistory();
 
   const GET_USER = gql`
     query GetUserInfo($netID: String) {

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -63,6 +63,7 @@ const Profile = () => {
   if (!user) return <div>Invalid User ID</div>;
 
   function goBack() {
+    localStorage.setItem('lastPage', 'profile');
     window.history.back();
   }
 

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -232,7 +232,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
 
   const leave = () => {
     let currentUser = localStorage.getItem('netid');
-    const returned = leaveRide().then(async (result) => {
+    leaveRide().then(async (result) => {
       if (ride.riders.length === 1) {
         // DELETE ride - use result (MongoID) to delete
         deleteRide().then(() => {
@@ -452,7 +452,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
                     </IconButton>
                 </Grid>
                 <Grid item xs = {10} justifyContent = "center">
-                  <ConfirmationText>{"Log in to view this user's profile?"}</ConfirmationText>
+                  <ConfirmationText>{"Log in to view this user's profile."}</ConfirmationText>
                     <LoginDialogActions>
                         <LoginButton onClick={handleLoginForUser} autoFocus>Rice SSO Login</LoginButton>
                     </LoginDialogActions>

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -199,6 +199,11 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
       setRide(ride)
      }
   }, [data])
+
+  useEffect(() => {
+    localStorage.setItem('lastRide', `ridesummary/${id}`);
+  }, [id])
+
    if (error) return <p>Error.</p>
   if (loading) return <LoadingDiv />
   if (!data) return <p>No data...</p>

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -103,6 +103,8 @@ const RideSummary = () => {
   const { addToast } = useToasts();
   // States to control for Dialog
   const [openLogin, setOpenLogin] = useState(false);
+  const [openUserProfile, setOpenUserProfile] = useState(false);
+  const [nextUserID, setNextUserID] = useState("");
   const [openConfirmation, setOpenConfirmation] = useState(false);
 
   const { data, loading, error } = useQuery(GET_RIDE, {
@@ -175,7 +177,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
     
   }, [newOwner, updateRide]) 
 
-  // Close the  box
+  // Close the box for attempting to login
   const handleCloseLogin= () => {
       setOpenLogin(false);
   };
@@ -272,6 +274,33 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
     }
   }
 
+  // ==================================== Attempts to Access User Profile ==================================
+  const accessUserProfile = (user_id) => {
+    console.log("Triggered access user profile", user_id);
+    if (localStorage.getItem("token") != null){
+      // Allow user to direct to profile page 
+      history.push("/profile/" + user_id);
+    } else {
+      // Warn the user that they must log in to checkout other user's profiles
+      setNextUserID(user_id); 
+      setOpenUserProfile(true); 
+      // addToast("You must log in to view user profiles.", { appearance: 'warning'});
+      // return 
+    }
+  }
+
+  const handleCloseLoginForUser = () => {
+    setOpenUserProfile(false); 
+    setNextUserID("");
+  }
+
+  const handleLoginForUser = () => {
+        localStorage.setItem('nextPage', 'profile/' + nextUserID);
+        let redirectURL = casLoginURL + '?service=' + SERVICE_URL;
+        window.open(redirectURL, '_self');
+  }
+  // =======================================================================================================
+
   const time = moment(ride.departureDate)
   const mon = time.format('MMM').toString()
   const day = time.format('DD').toString()
@@ -325,7 +354,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
       <RidersDiv>
         <HostDiv>Host</HostDiv>
         <RidersComponents>
-          <div onClick={e => history.push("/profile/" + ride.owner.netid)}>
+          <div onClick={e => accessUserProfile(ride.owner.netid)}>
             <OneRiderContainer>
                 <div key={ride.owner.netid}>
                   <IoPersonCircleSharpDiv>
@@ -341,7 +370,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
             <hr></hr>
           </LineDiv>
           {ride.riders.filter((x) => x.netid !== ride.owner.netid).map((person) => (
-            <div onClick={e => history.push("/profile/" + person.netid)}>
+            <div onClick={e => accessUserProfile(person.netid)}>
               <OneRiderContainer>
                 <div key={person.netid}>
                   <IoPersonCircleSharpDiv>
@@ -360,8 +389,6 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
         {ride.notes || 'No ride notes'}
         </NotesDiv>
       </RidersDiv>
-
-      
             
       <ButtonContainer>
         {ride.riders.map((person) => person.netid).includes(localStorage.getItem('netid')) ?
@@ -406,6 +433,25 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
                   <ConfirmationText>{confirmationText}</ConfirmationText>
                     <LoginDialogActions>
                         <LoginButton onClick={join} autoFocus>Got it! Join Ride</LoginButton>
+                    </LoginDialogActions>
+                  </Grid>
+            </Grid>
+      </JoinRideDialog>
+      <JoinRideDialog
+                open={openUserProfile}
+                onClose={handleCloseLoginForUser}
+            >
+            <Grid container spacing = {12} justifyContent = "center">
+                <Grid item sm = {11} xs = {10}/>
+                <Grid item sm = {1} xs = {2}>
+                    <IconButton onClick = {handleCloseLoginForUser} size = "medium">
+                        <CloseIcon />
+                    </IconButton>
+                </Grid>
+                <Grid item xs = {10} justifyContent = "center">
+                  <ConfirmationText>{"You must be logged in to view user profiles."}</ConfirmationText>
+                    <LoginDialogActions>
+                        <LoginButton onClick={handleLoginForUser} autoFocus>Rice SSO Login</LoginButton>
                     </LoginDialogActions>
                   </Grid>
             </Grid>

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -254,7 +254,6 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
 
     });
     // If numUsers == 1, show delete ride
-    console.log(returned);
     // console.log(result);
     // window.location.reload();
     // console.log(result);

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -276,7 +276,6 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
 
   // ==================================== Attempts to Access User Profile ==================================
   const accessUserProfile = (user_id) => {
-    console.log("Triggered access user profile", user_id);
     if (localStorage.getItem("token") != null){
       // Allow user to direct to profile page 
       history.push("/profile/" + user_id);
@@ -449,7 +448,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
                     </IconButton>
                 </Grid>
                 <Grid item xs = {10} justifyContent = "center">
-                  <ConfirmationText>{"You must be logged in to view user profiles."}</ConfirmationText>
+                  <ConfirmationText>{"Log in to view this user's profile?"}</ConfirmationText>
                     <LoginDialogActions>
                         <LoginButton onClick={handleLoginForUser} autoFocus>Rice SSO Login</LoginButton>
                     </LoginDialogActions>

--- a/client/src/common/Routes.js
+++ b/client/src/common/Routes.js
@@ -131,7 +131,7 @@ export const Routes = () => {
           <CheckTokenRoute path={'/userAuth'} component={withRouter(UserAuth)} />
           <CheckTokenRoute path={'/login'} component={withRouter(Login)} />
           <CheckTokenRoute path={'/onboarding'} component={withRouter(Onboarding)} />
-          <CheckTokenRoute path={'/profile/:id'} component={withRouter(Profile)} />
+          <PrivateRoute path={'/profile/:id'} component={withRouter(Profile)} />
           <CheckTokenRoute path={'/'} exact component={withRouter(Home)} />
           <CheckTokenRoute path={'/home'} component={withRouter(Home)} />
           <PrivateRoute


### PR DESCRIPTION
# Description

The task considered two components: 

- Making the profile page a private route
- Incorporate login pop-up for any attempts to access another user's profile in ride summary before logging in

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have attempted to access a profile page via URL directly (routes back to landing page) and access a profile by clicking on the profile card in ride summary pages. There is a problem with pressing the back button once the user lands on the profile page from Onboarding. 