### PR TITLE
Removes "Payment" Section in Past Rides

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "client",
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.0.0-beta.50",

--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -93,7 +93,10 @@ const YourRides = (paid) => {
                 </UpcomingRidesSection>
 
                 <PastRidesSection>
-                    <PastRideTitle><TitleText>Past Rides</TitleText><TitleText>Payments</TitleText></PastRideTitle>
+                    <PastRideTitle>
+                        <TitleText>Past Rides</TitleText>
+                        {/* <TitleText>Payments</TitleText> */}
+                    </PastRideTitle>
                     {prevRides.map(ride => {
                         return (
                             <PastRideCard 


### PR DESCRIPTION
# Description

Gets rid of the "Payment" section in the header of Past Rides on the YourRides page

## Type of change

- [ ] Remove to-be-implemented feature

# How Has This Been Tested?

Tested visually!
