### PR TITLE
Fix duplicate user bug (case-sensitive netid)

### DIFF
--- a/api/schema/UserSchema.js
+++ b/api/schema/UserSchema.js
@@ -41,6 +41,9 @@ UserTC.addResolver({
       // Get the netid of the authenticated user
       let { netid } = authenticationResponse;
 
+      // force netid to be lowercase to prevent duplicate user bug
+      netid = netid.toLowerCase();
+
       // Check if user exists based on netid
       let exists = await User.exists({ netid: netid });
       if (!exists) {


### PR DESCRIPTION
# Description

Fixed a bug where if you capitalized your netid you would be considered a different user. This PR sets the netid to be lowercase in the UserSchema authenticate resolver to fix it.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Delete yourself from the DB. In an incognito tab, login with a lowercase netid and see that you will be asked to onboard. In a new incognito tab, login with a capitalized netid and see that you will not be asked to onboard again.

Alternatively, you can try to login with a capitalized netid and see that it becomes lowercase in the DB.
