### PR TITLE
Phone numbers cannot be non-numeric

### DIFF
--- a/client/src/Pages/Onboarding/OnboardingForm.js
+++ b/client/src/Pages/Onboarding/OnboardingForm.js
@@ -34,7 +34,12 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
         if (phone === "") { 
             addToast("Please fill in your phone number.", { appearance: 'error' });
             return
-        }  
+        }
+        
+        if (/^[0-9]+$/.test(phone) === false) {
+            addToast("Phone number must only contain digits.", { appearance: 'error' });
+            return
+        }
 
     return onSubmit({
       firstName,

--- a/client/src/Pages/Profile/ProfileDialog.js
+++ b/client/src/Pages/Profile/ProfileDialog.js
@@ -216,6 +216,11 @@ export default function ProfileDialog(props) {
                         return
                     } 
 
+                    if (/^[0-9]+$/.test(user.phone) === false) {
+                      addToast("Phone number must only contain digits.", { appearance: 'error' });
+                      return
+                    }
+
                     if (changesMade) {
                       updateUserInfo();
                     }


### PR DESCRIPTION
# Description

Similar to a blank name or phone, now added a check for a non-numeric phone number in onboarding and edit profile.

## Type of change

Please delete options that are not relevant.

[ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Try to onboard or edit your profile with a non-numeric phone number. That's right you can't.
