### PR TITLE
Fixed profile routing to be dependent on localStorage lastPage

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -2,3 +2,5 @@ REACT_APP_SERVICE_URL=http://localhost:3001/auth
 REACT_APP_BACKEND_URL=http://localhost:3000/api
 REACT_APP_GRAPHQL_URL=http://localhost:3000/graphql
 REACT_APP_GRAPHQL_WS_URL=ws://localhost:3000/graphql
+SENDER_EMAIL=ricecarpool@gmail.com
+SENDER_EMAIL_PASSWORD=RiceAppsCarpool!

--- a/client/.env
+++ b/client/.env
@@ -2,5 +2,3 @@ REACT_APP_SERVICE_URL=http://localhost:3001/auth
 REACT_APP_BACKEND_URL=http://localhost:3000/api
 REACT_APP_GRAPHQL_URL=http://localhost:3000/graphql
 REACT_APP_GRAPHQL_WS_URL=ws://localhost:3000/graphql
-SENDER_EMAIL=ricecarpool@gmail.com
-SENDER_EMAIL_PASSWORD=RiceAppsCarpool!

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -62,12 +62,22 @@ const Profile = () => {
 
   if (!user) return <div>Invalid User ID</div>;
 
+  if (localStorage.getItem("lastPage") && localStorage.getItem("lastPage") === "profile/" + user.netid){
+    window.open("/search", "_self");
+  }
+
   function goBack() {
-    if (localStorage.getItem("lastPage") === "onboarding"){
-      localStorage.setItem("skipOnboarding", "true");
+    if (localStorage.getItem("lastPage")){
+      const previous = localStorage.getItem("lastPage"); 
+      if (previous === "onboarding"){
+        localStorage.setItem("skipOnboarding", "true");
+      }
+      localStorage.setItem('lastPage', 'profile/' + user.netid);
+      window.open("/" + previous, '_self');
+    } else {
+      window.open("/search", "_self");
     }
-    localStorage.setItem('lastPage', 'profile/' + user.netid);
-    window.history.back();
+    
   }
 
   return (

--- a/client/src/Pages/Profile/Profile.js
+++ b/client/src/Pages/Profile/Profile.js
@@ -62,19 +62,27 @@ const Profile = () => {
 
   if (!user) return <div>Invalid User ID</div>;
 
-  if (localStorage.getItem("lastPage") && localStorage.getItem("lastPage") === "profile/" + user.netid){
-    window.open("/search", "_self");
-  }
-
   function goBack() {
-    if (localStorage.getItem("lastPage")){
+    // Check for LastPage and that there is NO record of profile -> profile loop
+    if (localStorage.getItem("lastPage") && !(localStorage.getItem("repeatProfiles"))){
       const previous = localStorage.getItem("lastPage"); 
       if (previous === "onboarding"){
         localStorage.setItem("skipOnboarding", "true");
       }
       localStorage.setItem('lastPage', 'profile/' + user.netid);
+      // Stuck on the same profile page...
+      if (previous === 'profile/' + user.netid){
+        window.open("/search", "_self");
+      }
+      // If the last page and current page are BOTH profile pages
+      if (previous.includes("profile")){
+        localStorage.setItem("repeatProfiles", "true"); 
+      }
       window.open("/" + previous, '_self');
     } else {
+      if (localStorage.getItem("repeatProfiles")){
+        localStorage.removeItem("repeatProfiles");
+      }
       window.open("/search", "_self");
     }
     

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -295,6 +295,7 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
   const accessUserProfile = (user_id) => {
     if (localStorage.getItem("token") != null){
       // Allow user to direct to profile page 
+      localStorage.setItem("lastPage", window.location.pathname.substring(1))
       history.push("/profile/" + user_id);
     } else {
       // Warn the user that they must log in to checkout other user's profiles

--- a/client/src/Pages/YourRides/YourRides.js
+++ b/client/src/Pages/YourRides/YourRides.js
@@ -49,6 +49,7 @@ const YourRides = (paid) => {
     document.title = "Your Rides";
 
     let netid = localStorage.getItem("netid")
+    localStorage.setItem("lastPage", "your-rides");
 
     // const [allRides, setAllRides] = useEffect([])
     const [prevRides, setPrevRides] = useState([])

--- a/client/src/common/NavBar/Navbar.js
+++ b/client/src/common/NavBar/Navbar.js
@@ -173,12 +173,18 @@ export default function ButtonAppBar (props) {
     window.open(redirectURL, '_self');
   }
 
+  const routeToProfile = () => {
+    localStorage.setItem("lastPage", window.location.pathname.substring(1));
+    window.open("/profile/" + localStorage.getItem('netid'), "_self");
+    toggleDrawer();
+  }
+
   const openFeedback = () => {
     window.open(feedbackURL, '_blank');
   }
 
   const showUsername = (toggleDrawer) => (
-    <ListItem button component = {Link} to = {"/profile/" + localStorage.getItem('netid')}  className={classes.usernameContainer} onClick = {toggleDrawer}>
+    <ListItem button className={classes.usernameContainer} onClick = {routeToProfile}>
       <Avatar className = {classes.avatarIcon}/>
       <ListItemText className = {classes.text} primary = {user.firstName + " " + user.lastName}/>
     </ListItem>


### PR DESCRIPTION
# Description

Modified how the profile page's back button functions. It now uses the localStorage's `lastPage` to determine which page to route back to. I have identified some key ways to route towards profile: 

- Navbar
- Ride Summary

And I have stored the last page on these respective pages when triggering actions that would navigate towards Profile. Now, if the user presses the email with some `lastPage` variable, then it would route them towards that page. 

With the way that my first commit worked, there are two bad scenarios I could think of:  
- If the user somehow closes the Carpool app on someone's profile, then opens the link to the same person's profile, tries to use the back button, then they would be stuck in this infinite loop since the `lastPage` is the current page they are on.
- If the user goes to one person's profile, then immediately goes to another person's profile... then they would be stuck in a loop between the two people's profiles. This is only possible if (a) they manually typed URLs or (b) use their own profile or someone else's. 

To accommodate for this, I added code in the second commit to deal with scenario B with the localStorage variable `repeatProfile` and to deal with scenario A where the last page is the exact same as the current one. Both would just route the user to the homepage. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By trying to route to the profile page from all possible pages available via the Navbar. Pressing the back button does take you to the intended page. Going through Find Ride -> Ride Summary -> Profile and then press back will take you back to the appropriate Ride Summary page. 

Special Cases: 
- If I spammed my own profile on the navbar a couple times (>2), then press the back button twice on the profile will take me to the home page. 
- If I lock myself by doing Shreyas -> Kai (Own) and then press back, then the lastPages will be alternating between the two people's profile URL. Due to the changes made in commit (2) you can at most go through two profile pages consecutively without being booted back to home page. So in this case, it would go back to Shreyas, and then go to the Find Rides page. 