### PR TITLE
UserAuth Error Fix

### DIFF
--- a/client/src/Pages/Auth/UserAuth.js
+++ b/client/src/Pages/Auth/UserAuth.js
@@ -45,7 +45,7 @@ const UserAuth = () => {
   } 
 
   // If the user returned to UserAuth from profile page, let them go further back
-  if (previous.includes("profile")){
+  if (previous && previous.includes("profile")){
     history.goBack();
   }
 
@@ -63,7 +63,8 @@ const UserAuth = () => {
             // Route to next page since user is verified
             window.open(destination, '_self'); 
           } else {
-            window.alert('Unexpected Behavior');
+            // No specified destination after userAuth? To homepage. 
+            window.open("/search", "_self");
           }
           
         }

--- a/client/src/common/Routes.js
+++ b/client/src/common/Routes.js
@@ -128,7 +128,7 @@ export const Routes = () => {
         <Navbar/>
         <Switch>
           <CheckTokenRoute path={'/alert'} component={withRouter(Alert)} />
-          <CheckTokenRoute path={'/userAuth'} component={withRouter(UserAuth)} />
+          <PrivateRoute path={'/userAuth'} component={withRouter(UserAuth)} />
           <CheckTokenRoute path={'/login'} component={withRouter(Login)} />
           <CheckTokenRoute path={'/onboarding'} component={withRouter(Onboarding)} />
           <PrivateRoute path={'/profile/:id'} component={withRouter(Profile)} />


### PR DESCRIPTION
# Description

UserAuth currently causes an error if the user attempts to go to the URL directly without having been logged in. I have fixed this issue by making it a private route, correcting the line of code that triggers an error (attempt to use `string.includes()` on a null object but expecting a string), and changing an unexpected flow to route towards search page instead of showing a user alert. Worth noting that the last item also only occurs if the user has not been onboarded, so it shouldn't ever prevent a user from reaching the onboarding form. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the function of the website for various onboarding and logging-in flow. There is no need for `userAuth` unless the user has at least gotten through the Rice SSO login. No code was changed related to an untampered onboarding process itself (only changed to route to search if the user somehow did something weird to arrive at userAuth without a `nextPage` item).
