### PR TITLE
Fixed Auto Join Flow

### DIFF
--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -273,7 +273,14 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
   }
 
   // console.log(data, loading, error);
-  if (localStorage.getItem('joinFromLogin') === "true") join();
+  if (localStorage.getItem('joinFromLogin') === "true") {
+    if (localStorage.getItem('token')){
+      join();
+    } else {
+      localStorage.setItem('joinFromLogin', 'false');
+    }
+  }
+  
   if (error) return <p>Error.</p>
   if (loading) return <p>Loading...</p>
   if (!data) return <p>No data...</p>


### PR DESCRIPTION
# Description

Fix the issue where ride join is automatically engaged when pressing back on Rice SSO login. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The bug no longer occurs if the student presses back on the Rice SSO page. And the join flow is still automatic in the case that they go through a complete log-in/onboarding flow. 