### PR TITLE
removed white box around ride notes

### DIFF
--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -208,7 +208,6 @@ const NotesDiv = styled.div`
   width: 85%;
   padding: 10px;  
   font-family: Josefin Sans;
-  background: #ffffff;
   border-radius: 5px;
 `
 const TextContainer = styled.div`


### PR DESCRIPTION
Removed white box around ride notes in ride summary 
Should be the same color as the background now.