### PR TITLE
Fix: (About Us) Route to top of page always

### DIFF
--- a/client/src/Pages/AboutUs/AboutUs.js
+++ b/client/src/Pages/AboutUs/AboutUs.js
@@ -1,4 +1,6 @@
 import React from "react";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import Typography from '@material-ui/core/Typography';
@@ -28,9 +30,16 @@ import{
 } from "./AboutUsstyles";
 
 
+
 const AboutUs = () => {
 
     document.title = "About Us";
+
+    // Reset to top of the page
+    const {pathname} = useLocation();
+    useEffect(() => {
+        window.scrollTo(0, 0); 
+    }, [pathname]);
 
     return (
         <AllDiv>


### PR DESCRIPTION
# Description

Previously, if you were routing to "About Us" from the middle of another page, it would bring you to the middle of the "About Us" page instead of the top. The navbar routing brings you to the top of all other pages as far as I can tell, besides "About Us". 

Made a quick fix by including a `useEffect` according to this site: https://v5.reactrouter.com/web/guides/scroll-restoration 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The code change is minimal and should not affect any other functionalities. I recorded videos for the before and after for contrasting purposes. 

-- Before -- 

https://user-images.githubusercontent.com/53880607/160254759-f1d2ee9d-5f4f-4519-8d11-1a6bc2ffa9c2.mov

-- After  --

https://user-images.githubusercontent.com/53880607/160254768-1a420482-e6b6-4b41-9af8-154dd44d624e.mov



