### PR TITLE
add back the white box around ride summary notes

### DIFF
--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -219,6 +219,7 @@ const NotesDiv = styled.div`
   width: 97%;
   padding: 10px;  
   color: rgba(128, 128, 128, 1);
+  background: #ffffff;
   
   font-family: Josefin Sans;
   border-radius: 5px;


### PR DESCRIPTION
We talked about being able to edit the ride notes, so the white box around the ride summary notes is now added back so it looks clickable (same as before now). 
