### PR TITLE
Form Validation: Automatically Trim Phone Number with Dashes

### DIFF
--- a/client/src/Pages/Onboarding/OnboardingForm.js
+++ b/client/src/Pages/Onboarding/OnboardingForm.js
@@ -24,9 +24,8 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
   const [venmo, setVenmo] = useState("");
   const { addToast } = useToasts();
 
-    const handleSubmit = () => {
+  const handleSubmit = () => {
 
- 
         if (firstName === "" || lastName === "") { 
             addToast("Please fill in your full name.", { appearance: 'error' });
             return
@@ -41,6 +40,8 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
             addToast("Phone number must only contain digits.", { appearance: 'error' });
             return
         }
+        
+        
 
     return onSubmit({
       firstName,
@@ -81,7 +82,7 @@ const OnboardingForm = ({ onSubmit, onCancel }) => {
             defaultValue={phone}
             name="phone"
             required
-            onChange={(e) => setPhone(e.target.value)}
+            onChange={(e) => setPhone(e.target.value.replace(/[ +-]/g, ''))}
           ></RequiredTextField>
         </InputBox>
         <InputBox>

--- a/client/src/Pages/Profile/ProfileDialog.js
+++ b/client/src/Pages/Profile/ProfileDialog.js
@@ -204,6 +204,9 @@ export default function ProfileDialog(props) {
                 <SaveButton
                   variant="contained"
                   onClick={() => {
+                    // trim out "-" from number
+                    setUserProps("phone", user.phone.replace(/[ +-]/g, '')); 
+
                     if (user.firstName === "" || user.lastName === "") { 
                       addToast("Please fill in your full name.", { appearance: 'error' });
                       return


### PR DESCRIPTION
# Description

Added the functionality to automatically trim away extraneous dashes for phone numbers on <Edit Profile> and <Onboarding> pages. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Has been tested by trying out phone numbers with dashes inside and confirming that only the non-dash numeric parts remain. 


https://user-images.githubusercontent.com/53880607/162589934-4eaee702-20d1-431b-8da1-cea41508eabb.mov

https://user-images.githubusercontent.com/53880607/162589939-3c68587d-4076-4f39-b06a-cae87624bc32.mov



