### PR TITLE
Specified that time refers to ride departure time

### DIFF
--- a/client/src/Pages/CreateRide/Create.js
+++ b/client/src/Pages/CreateRide/Create.js
@@ -218,7 +218,7 @@ const Create = ({ onCreate }) => {
         </Grid>
 
         <Grid item xs={12}>
-          <InputBox id="Date and Time">Date and Time (CST)</InputBox>
+          <InputBox id="Date and Time">Ride Date and Time (CST)</InputBox>
           <MuiThemeProvider theme={customTheme}>
             <MuiPickersUtilsProvider utils={MomentUtils}>
               <DateBox

--- a/client/src/Pages/RideSummary/RideSummary.js
+++ b/client/src/Pages/RideSummary/RideSummary.js
@@ -41,6 +41,7 @@ import {
   DepartureIconDiv,
   CalendarText,
   TimeText, 
+  TimeTextDetail, 
   ConfirmationText
 } from './RideSummaryStyles.js'
 import { Grid, IconButton } from '@material-ui/core';
@@ -371,6 +372,9 @@ const [deleteRide] = useMutation(DELETE_RIDE, {
               <TimeText>
                 {hour}
               </TimeText>
+              <TimeTextDetail>
+                (Ride Departure Time)
+              </TimeTextDetail>
             </DateDiv>
           </InnerLocationDiv>
         </LocationDiv>

--- a/client/src/Pages/RideSummary/RideSummaryStyles.js
+++ b/client/src/Pages/RideSummary/RideSummaryStyles.js
@@ -99,6 +99,7 @@ const LocationText = styled.div`
 const DateDiv = styled.div`
   display: grid;
   grid-template-columns: 1fr 2fr 1fr 1fr 2fr;
+  //grid-template-rows: 1fr 1fr;
   font-family: Josefin Sans;
   font-style: normal;
   font-weight: normal;
@@ -134,6 +135,13 @@ const TimeText = styled.div`
   grid-column: 5;
   font-family: Josefin Sans;
   grid-row: 1;
+`
+
+const TimeTextDetail = styled.div`
+  grid-column: 4 / span 2;
+  grid-row: 2;
+  font-family: Josefin Sans;
+  font-size: 1.5vh;
 `
 
 const HostDiv = styled.div`
@@ -386,5 +394,6 @@ export {
   DepartureIconDiv,
   CalendarText,
   TimeText, 
+  TimeTextDetail,
   ConfirmationText
 }


### PR DESCRIPTION
# Description

Added "Ride Date and Time" in Create Ride and added "Ride Departure Time" under the time in Ride Summary.
This is to remove ambiguity surrounding the meaning of "time".

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Observe the text on the create ride page and the ride summary page.
