### PR TITLE
Fix wide login button on desktop

### DIFF
--- a/client/src/Pages/Onboarding/Alert.styles.js
+++ b/client/src/Pages/Onboarding/Alert.styles.js
@@ -15,6 +15,7 @@ export const LoginButton = withStyles({
         justifyContent: 'center',
         background: '#2075D8',
         width: '55vw',
+        maxWidth: '300px',
         borderRadius: 25,
         color: 'white',
         height: '5vh',


### PR DESCRIPTION
# Description

Login button was too wide on desktop, so I set a max width for the button.

Before: ![image](https://user-images.githubusercontent.com/47200969/163687724-39270ca5-d829-4b28-9c2b-0c04610f35d3.png)
After: 
![image](https://user-images.githubusercontent.com/47200969/163687704-3f3f44d8-abc7-4847-b129-b67ad9d76f3c.png)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Make sure you're logged out, and perform an action that requires you to login. Ensure the button is correct
