### PR TITLE
Ddos protection

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -3,6 +3,7 @@ var express = require('express');
 const { ApolloServer } = require('apollo-server-express');
 var exjwt = require('express-jwt');
 var cors = require('cors')
+var Ddos = require('ddos')
 
 // Import hidden values from .env
 import { PORT, SECRET, REDIS_PORT, REDIS_HOST, REDIS_USERNAME, REDIS_PASSWORD } from './config';
@@ -59,6 +60,10 @@ app.use(cors({
 app.use(bodyParser.json())
 // Set dryRun to try for adding queries to whitelist
 app.post('/graphql', graphqlWhitelist({ store, validationErrorFn, dryRun: false }))
+
+// ddos protection
+var ddos = new Ddos({burst:10, limit:15});
+app.use(ddos.express);
 
 app.use(function(req, res, next) {
   if (req.headers.origin) {

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
+    "ddos": "^0.2.1",
     "debug": "~2.6.9",
     "dotenv": "^8.6.0",
     "express": "~4.16.1",


### PR DESCRIPTION
# Description

Adds DDoS protection to Carpool, limiting requests to bursts/limits. More details here https://www.npmjs.com/package/ddos

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

TBH I'm not sure how to test this without performing an actual DDoS attack, but the package blocked requests from the create ride page, which was sending infinite numbers of requests. This has since been fixed. Just make sure the website still works as a whole and all queries are functional.
